### PR TITLE
Enhance audio reactivity engine and UI

### DIFF
--- a/NEXT_GEN_SOUND_REACTIVITY_PROPOSAL.md
+++ b/NEXT_GEN_SOUND_REACTIVITY_PROPOSAL.md
@@ -1,0 +1,72 @@
+# Flow — Next-Generation Sound Reactivity Vision
+
+## 1. Current Baseline Snapshot
+- Web Audio engine already captures FFT magnitudes, coarse bands (bass/mid/treble), centroid, flux, beat gate, and optional tempo probe. The signal is smoothed with shared attack/release envelopes.
+- Audio router modulates key simulation fields (jet, vortex, curl, orbit, viscosity, etc.) and some environment motion. Visual post-processing hooks exist but are mostly dormant.
+- A dedicated audio panel exposes high-level sensitivity controls, routing presets, basic diagnostics, and file selection. Per-feature smoothing and deeper diagnostics are not yet available.
+- Visual feedback largely leans on bulk band energy; higher-order descriptors (spectral tilt, texture, transient density) and per-parameter baselines are absent, making fine art direction difficult.
+
+## 2. North-Star Experience
+Deliver a "living instrument" that responds like a seasoned VJ: music carves the flow volume, sculpts light and glass, and breathes through camera motion. The system should:
+1. **Hear like a musician** – multi-resolution analysis with confident beat, tempo, and tonal balance understanding.
+2. **Move like choreography** – fluid fields, emitters, and particle kinematics reshape with intent rather than jitter.
+3. **Glow like cinema** – post FX and color grading pulse with restraint, keeping clarity and avoiding fatigue.
+4. **Feel playable** – creators remix mappings instantly, save/load setups, and trust meters & presets for guidance.
+
+## 3. Upgrade Pillars
+- **Signal Intelligence**: Expand features to multi-band (sub, presence, air), tonal tilt, transient density, and timbral texture while keeping CPU cost low through shared FFT passes.
+- **Kinematic Orchestration**: Introduce baseline-aware routing so physics parameters swing around art-directed anchors (radius, viscosity, emitter cadence) without runaway feedback.
+- **Atmospheric Dynamics**: Drive bloom, exposure, saturation, DOF, and camera/environment sway with tempo-aware envelopes for cinematic pacing.
+- **Creative Surface**: Elevate the audio panel with per-feature envelopes, richer diagnostics (tempo, multi-band meters), and deeper routing options packaged in themed styles.
+
+## 4. System Design
+### 4.1 Signal & Feature Pipeline
+- Maintain current analyser chain with optional AGC/gating. Add log-spaced sub/low-mid/high-mid/presence/air averages, brightness ratio, roughness (spectral derivative), and transient density (flux vs. energy).
+- Provide individual attack/release envelopes per feature plus global smoothing. Allow on-the-fly FFT size and threshold tuning.
+- Track tempo phase & confidence; expose a sine/ramp helper for tempo-locked modulations.
+
+### 4.2 Motion, Physics & Emitters
+- Route sub bass to emitter radius/strength to punch fluid ejections while preserving average radius via baseline tracking.
+- Use presence/air energy and spectral brightness to modulate curl/noise intensity and noise grain.
+- Map transient density and beat envelopes to viscosity, APIC blend, and newly introduced orbit/curl accelerations with hard clamps.
+- Tempo phase feeds slow breathing loops on vortex rotation/orbit as well as camera/environment sway.
+
+### 4.3 Visual & Atmospheric Layer
+- Bloom strength and exposure respond to presence/brightness with baseline blending, preventing washout.
+- Color saturation & hue leverage spectral tilt; chroma/grain/DOF amounts track transient texture for cinematic grit when percussion hits.
+- Introduce optional camera micro-roll/orbit tied to tempo for spatial storytelling.
+
+### 4.4 Interaction & Panel Experience
+- Expand meters: multi-band levels, tilt/texture readouts, tempo BPM + confidence.
+- Provide envelope editor folders per feature, gating & AGC controls, and routing presets that cover cinematic, nebula, glitch, and ambient archetypes.
+- Allow re-basing of controlled parameters so manual tweaks reset the "home" around which audio modulations oscillate.
+
+### 4.5 Performance & Safety
+- Keep analyser work allocation-free (reuse typed arrays) and maintain <0.5ms/frame on desktop.
+- Hard clamp all routed parameters; store untouched baselines and smoothly restore when audio disables.
+- Offer master intensity/reactivity multipliers for emergency tames during performance.
+
+## 5. Roadmap & Milestones
+1. **Foundation (this pass)**
+   - Implement extended feature set (sub/presence/air, tilt, roughness, transient, brightness) with per-feature envelopes.
+   - Upgrade router with baseline tracking, new visual/physics routes (bloom, exposure, DOF, radii) and tempo-aware sway.
+   - Enhance audio panel for new controls, per-feature envelope editor, and enriched diagnostics.
+2. **Expressive Motion**
+   - Add particle emitter pulses, orbit path modulation, and camera micro-roll driven by tempo & tilt.
+   - Introduce curve editors (pow/s-curve) per route plus stochastic offsets for organic feel.
+3. **Cinematic Atmosphere**
+   - Integrate LUT/grade presets, light linking, and dynamic volumetrics keyed to brightness & texture.
+4. **Creative UX**
+   - Preset browser with preview thumbnails, MIDI/OSC bindings, and session logging for later playback.
+
+## 6. Success Rubric
+| Pillar | Excellent | Acceptable | Needs Work |
+| --- | --- | --- | --- |
+| Musicality | Beat & tempo within ±2 BPM, tilt tracks tonal shifts, transient meter stable | Minor drift or occasional false positives | Frequent misfires or lag |
+| Motion & Physics | Audio pushes jets/vortex within safe bounds, no numerical blowups | Rare clamped spikes, system self-recovers | Visible instability or flat response |
+| Visual Atmosphere | Bloom/exposure breathe without clipping; saturation resets when audio stops | Occasional over-bright frames | Persistent washout or dullness |
+| UX & Panel | Multi-band meters reliable, envelope editor intuitive, presets save/load | Minor UI quirks | Controls confusing or mis-synced |
+
+## 7. Immediate Next Steps
+- Ship extended feature extraction & envelope control, update router/panel (in progress with this implementation).
+- Capture feedback on artistic feel, retune gains/curves, and line up emitter/camera choreography for the following pass.

--- a/src/app.js
+++ b/src/app.js
@@ -286,21 +286,42 @@ class App {
                 conf._audioBeat = clamp( f.beat * conf.audioBeatBoost, 0.0, 1.0 );
                 conf._audioBass = clamp( f.bass * conf.audioBassGain * sens, 0.0, 1.0 );
                 conf._audioMid = clamp( f.mid * conf.audioMidGain * sens, 0.0, 1.0 );
+                conf._audioLowMid = clamp( f.lowMid * conf.audioMidGain * sens, 0.0, 1.0 );
+                conf._audioHighMid = clamp( f.highMid * conf.audioTrebleGain * sens, 0.0, 1.0 );
                 conf._audioTreble = clamp( f.treble * conf.audioTrebleGain * sens, 0.0, 1.0 );
+                conf._audioSub = clamp( f.sub * (conf.audioSubGain || 1.0) * sens, 0.0, 1.0 );
+                conf._audioPresence = clamp( f.presence * (conf.audioPresenceGain || 1.0) * sens, 0.0, 1.0 );
+                conf._audioAir = clamp( f.air * (conf.audioAirGain || 1.0) * sens, 0.0, 1.0 );
+                const tiltGain = conf.audioColorTilt || 1.0;
+                const textureGain = conf.audioTextureGain || 1.0;
+                conf._audioTilt = clamp( f.tilt * tiltGain, 0.0, 1.0 );
+                conf._audioRoughness = clamp( f.roughness * textureGain, 0.0, 1.0 );
+                conf._audioTransient = clamp( f.transient * textureGain, 0.0, 1.0 );
+                conf._audioBrightness = clamp( f.brightness, 0.0, 1.0 );
                 conf._audioTempoPhase = f.tempoPhase01 || 0.0;
                 conf._audioTempoBpm = f.tempoBpm || 0.0;
+                conf._audioTempoConf = f.tempoConf || 0.0;
                 // Router applies mappings and environment sway
                 this.router.apply({
                     level: conf._audioLevel,
                     beat: conf._audioBeat,
                     bass: conf._audioBass,
                     mid: conf._audioMid,
+                    lowMid: conf._audioLowMid,
+                    highMid: conf._audioHighMid,
                     treble: conf._audioTreble,
+                    sub: conf._audioSub,
+                    presence: conf._audioPresence,
+                    air: conf._audioAir,
                     centroid: f.centroid,
                     flux: f.flux,
                     fluxBass: f.fluxBass,
                     fluxMid: f.fluxMid,
                     fluxTreble: f.fluxTreble,
+                    tilt: conf._audioTilt,
+                    roughness: conf._audioRoughness,
+                    transient: conf._audioTransient,
+                    brightness: conf._audioBrightness,
                     tempoBpm: f.tempoBpm,
                     tempoPhase01: f.tempoPhase01,
                     tempoConf: f.tempoConf,
@@ -308,8 +329,13 @@ class App {
             } catch (e) { /* noop */ }
         } else {
             conf._audioLevel = conf._audioBeat = conf._audioBass = conf._audioMid = conf._audioTreble = 0;
+            conf._audioSub = conf._audioPresence = conf._audioAir = 0;
+            conf._audioLowMid = conf._audioHighMid = 0;
+            conf._audioTilt = conf._audioRoughness = conf._audioTransient = conf._audioBrightness = 0;
+            conf._audioTempoPhase = conf._audioTempoBpm = conf._audioTempoConf = 0;
             // Reset environment rotations when audio off
             if (this._envBase) { conf.bgRotY = this._envBase.bg; conf.envRotY = this._envBase.env; }
+            if (this.router && this.router.reset) this.router.reset(conf, this._envBase);
         }
 
         await this.mlsMpmSim.update(delta,elapsed);

--- a/src/audio/audioEngine.js
+++ b/src/audio/audioEngine.js
@@ -18,6 +18,11 @@ export class AudioEngine {
       bass: 0,
       mid: 0,
       treble: 0,
+      sub: 0,
+      lowMid: 0,
+      highMid: 0,
+      presence: 0,
+      air: 0,
       centroid: 0,
       flux: 0,
       beat: 0,
@@ -27,9 +32,28 @@ export class AudioEngine {
       fluxBass: 0,
       fluxMid: 0,
       fluxTreble: 0,
+      tilt: 0,
+      roughness: 0,
+      transient: 0,
+      brightness: 0,
     };
     // Per-feature envelopes
-    this._env = { level: 0, bass: 0, mid: 0, treble: 0, beat: 0 };
+    this._env = {
+      level: 0,
+      bass: 0,
+      mid: 0,
+      treble: 0,
+      beat: 0,
+      sub: 0,
+      lowMid: 0,
+      highMid: 0,
+      presence: 0,
+      air: 0,
+      tilt: 0,
+      roughness: 0,
+      transient: 0,
+      brightness: 0,
+    };
     this._envCfg = { attack: 0.5, release: 0.2 };
     this._envCfgMap = {
       level: { attack: 0.5, release: 0.2 },
@@ -37,6 +61,15 @@ export class AudioEngine {
       mid: { attack: 0.5, release: 0.2 },
       treble: { attack: 0.5, release: 0.2 },
       beat: { attack: 0.6, release: 0.2 },
+      sub: { attack: 0.5, release: 0.25 },
+      lowMid: { attack: 0.5, release: 0.25 },
+      highMid: { attack: 0.45, release: 0.25 },
+      presence: { attack: 0.45, release: 0.25 },
+      air: { attack: 0.45, release: 0.25 },
+      tilt: { attack: 0.35, release: 0.25 },
+      roughness: { attack: 0.3, release: 0.45 },
+      transient: { attack: 0.7, release: 0.35 },
+      brightness: { attack: 0.45, release: 0.3 },
     };
     // Beat / flux state
     this._beatState = { thr: 0.0, avg: 0.0, last: 0, hold: 0.12 };
@@ -204,6 +237,7 @@ export class AudioEngine {
     const t0 = toBin(2000), t1 = toBin(8000);
 
     const avgBand = (lo, hi) => {
+      hi = Math.max(lo, Math.min(N - 1, hi));
       let s = 0, c = 0;
       for (let i = lo; i <= hi; i++) { s += mag[i]; c++; }
       return c ? s / c : 0;
@@ -211,6 +245,28 @@ export class AudioEngine {
     const bass = avgBand(b0, b1);
     const mid = avgBand(m0, m1);
     const treble = avgBand(t0, t1);
+    const subHi = toBin(60);
+    const lowMid0 = toBin(60), lowMid1 = toBin(400);
+    const highMid0 = toBin(1000), highMid1 = toBin(4000);
+    const presence0 = toBin(4000), presence1 = toBin(8000);
+    const air0 = toBin(8000), air1 = toBin(16000);
+    const sub = avgBand(b0, subHi);
+    const lowMid = avgBand(lowMid0, lowMid1);
+    const highMid = avgBand(highMid0, highMid1);
+    const presence = avgBand(presence0, presence1);
+    const air = avgBand(air0, air1);
+
+    const lowEnergy = (sub + bass + lowMid) / 3;
+    const highEnergy = (treble + highMid + presence + air) / 4;
+    const tilt = Math.max(0, Math.min(1, 0.5 + 0.5 * (highEnergy - lowEnergy)));
+    const brightness = Math.max(0, Math.min(1, highEnergy / (lowEnergy + highEnergy + 1e-6)));
+
+    let rough = 0;
+    for (let i = 1; i < N; i++) {
+      rough += Math.abs(mag[i] - mag[i - 1]);
+    }
+    const roughness = Math.max(0, Math.min(1, (rough / N) * 0.65));
+
 
     // Spectral centroid
     let num = 0, den = 0;
@@ -245,6 +301,8 @@ export class AudioEngine {
       thr = this._beatState.avg * this._thrK;
     }
     this._beatState.thr = thr;
+    const transient = Math.max(0, Math.min(1, (flux / (sum + 1e-6)) * 0.65));
+
     let beat = 0;
     if (flux > thr && this._gateTimer < this._gateHold) {
       const now = (performance.now() || 0) / 1000;
@@ -270,12 +328,21 @@ export class AudioEngine {
     this._features.bass = applyEnv('bass', bass);
     this._features.mid = applyEnv('mid', mid);
     this._features.treble = applyEnv('treble', treble);
+    this._features.sub = applyEnv('sub', sub);
+    this._features.lowMid = applyEnv('lowMid', lowMid);
+    this._features.highMid = applyEnv('highMid', highMid);
+    this._features.presence = applyEnv('presence', presence);
+    this._features.air = applyEnv('air', air);
     this._features.centroid = centroid;
     this._features.flux = flux;
     this._features.beat = applyEnv('beat', beat);
     this._features.fluxBass = fluxBass;
     this._features.fluxMid = fluxMid;
     this._features.fluxTreble = fluxTreble;
+    this._features.tilt = applyEnv('tilt', tilt);
+    this._features.roughness = applyEnv('roughness', roughness);
+    this._features.transient = applyEnv('transient', transient);
+    this._features.brightness = applyEnv('brightness', brightness);
 
     // Tempo estimation (simple ACF over recent flux)
     if (this._tempoEnabled) {

--- a/src/audio/router.js
+++ b/src/audio/router.js
@@ -20,12 +20,29 @@ export class AudioRouter {
       curlStrength: { enable: true, source: 'treble', gain: 1.2, curve: 1.2 },
       orbitStrength: { enable: true, source: 'mid', gain: 1.0, curve: 1.0 },
       waveAmplitude: { enable: true, source: 'beat', gain: 1.2, curve: 1.0 },
+      jetRadius: { enable: false, source: 'sub', gain: 6.0, curve: 1.0 },
+      vortexRadius: { enable: false, source: 'presence', gain: 5.0, curve: 1.0 },
+      bloomStrength: { enable: true, source: 'presence', gain: 0.6, curve: 1.1 },
+      exposure: { enable: false, source: 'brightness', gain: 0.35, curve: 1.0 },
+      postSaturation: { enable: true, source: 'tilt', gain: 0.6, curve: 1.0 },
+      postContrast: { enable: false, source: 'transient', gain: 0.4, curve: 1.0 },
+      dofAmount: { enable: false, source: 'roughness', gain: 0.5, curve: 1.0 },
     };
+    this._bases = {};
+    this._lastApplied = {};
   }
 
   setMaster(v) { this.master = clamp(v ?? 1.0, 0, 2); }
   setEnabled(v) { this.enabled = !!v; }
-  setRoutes(routes) { this.routes = { ...this.routes, ...routes }; }
+  setRoutes(routes) {
+    if (!routes) return;
+    const next = { ...this.routes };
+    Object.keys(routes).forEach((key) => {
+      const current = next[key] || {};
+      next[key] = { ...current, ...routes[key] };
+    });
+    this.routes = next;
+  }
   getRoutes() { return JSON.parse(JSON.stringify(this.routes)); }
   toJSON() { return { enabled: this.enabled, master: this.master, intensity: this.intensity, reactivity: this.reactivity, routes: this.getRoutes() }; }
   fromJSON(data) {
@@ -43,13 +60,57 @@ export class AudioRouter {
   setIntensity(v) { this.intensity = clamp(v ?? 1.0, 0.2, 2.0); }
   setReactivity(v) { this.reactivity = clamp(v ?? 1.0, 0.5, 2.0); }
 
+  _ensureBase(conf, key) {
+    if (!conf || !key) return this._bases[key];
+    const cur = conf[key];
+    if (cur === undefined || cur === null || Number.isNaN(cur)) return this._bases[key];
+    if (this._bases[key] === undefined) this._bases[key] = cur;
+    const last = this._lastApplied[key];
+    if (last !== undefined && Math.abs(cur - last) > 0.01) {
+      this._bases[key] = cur;
+    }
+    return this._bases[key];
+  }
+
+  _setConf(conf, key, value) {
+    if (value === undefined || value === null || Number.isNaN(value)) return;
+    conf[key] = value;
+    this._lastApplied[key] = value;
+  }
+
+  _restoreTowardsBase(conf, key) {
+    if (!conf || !key) return;
+    const base = this._bases[key];
+    if (base === undefined) return;
+    const cur = conf[key];
+    if (cur === undefined || cur === null || Number.isNaN(cur)) return;
+    if (Math.abs(cur - base) > 0.001) {
+      this._setConf(conf, key, base);
+    } else {
+      this._lastApplied[key] = cur;
+    }
+  }
+
+  reset(conf, envBase) {
+    if (!conf) return;
+    if (envBase) {
+      conf.bgRotY = envBase.bg;
+      conf.envRotY = envBase.env;
+    }
+    Object.keys(this._bases).forEach((key) => {
+      if (this._bases[key] !== undefined) {
+        this._setConf(conf, key, this._bases[key]);
+      }
+    });
+  }
+
   _pulse(f, src) {
     const val = clamp((f[src] ?? 0), 0, 1);
     const t = (x) => Math.tanh(x);
     let onset = 0;
-    if (src === 'bass') onset = (f.fluxBass || 0);
-    else if (src === 'mid') onset = (f.fluxMid || 0);
-    else if (src === 'treble') onset = (f.fluxTreble || 0);
+    if (src === 'bass' || src === 'sub') onset = (f.fluxBass || 0);
+    else if (src === 'mid' || src === 'lowMid' || src === 'highMid') onset = (f.fluxMid || 0);
+    else if (src === 'treble' || src === 'presence' || src === 'air') onset = (f.fluxTreble || 0);
     const onsetN = clamp(0.6 * t((onset || 0) * 0.8), 0, 1);
     return clamp(val * 0.7 + onsetN * 0.3 + (f.beat || 0) * 0.1, 0, 1);
   }
@@ -57,13 +118,21 @@ export class AudioRouter {
   apply(features, conf, elapsed, envBase) {
     if (!this.enabled) return;
     const g = this.master * this.intensity;
-    const f = features;
+    const f = features || {};
+    const tempoPhase = clamp((f.tempoPhase01 ?? 0), 0, 1);
+    const tempoConf = clamp((f.tempoConf ?? 0), 0, 1);
+    const tempoWave = tempoConf > 0.25 ? Math.sin(tempoPhase * Math.PI * 2) : Math.sin(elapsed * 1.2);
+    const tempoPulse = clamp(0.5 + 0.5 * tempoWave, 0, 1);
 
-    // Map helpers
-    const get = (src) => clamp((f[src] ?? 0), 0, 1);
-    const shaped = (src, curve) => (src === 'bass' || src === 'mid' || src === 'treble') ? this._shape(this._pulse(f, src), curve) : this._shape(get(src), curve);
+    const get = (src) => {
+      if (src === 'tempoWave') return tempoPulse;
+      if (src === 'tempoPhase01') return tempoPhase;
+      return clamp((f[src] ?? 0), 0, 1);
+    };
+    const shaped = (src, curve) => (src === 'bass' || src === 'mid' || src === 'treble' || src === 'sub' || src === 'lowMid' || src === 'highMid' || src === 'presence' || src === 'air')
+      ? this._shape(this._pulse(f, src), curve)
+      : this._shape(get(src), curve);
 
-    // Jet strength
     if (conf.jetEnabled && this.routes.jetStrength.enable) {
       const r = this.routes.jetStrength;
       let v = conf.jetStrength * 0.85 + shaped(r.source, r.curve) * r.gain * 0.15;
@@ -71,21 +140,48 @@ export class AudioRouter {
       conf.jetStrength = clamp(v * g, 0, 4.0);
     }
 
-    // Vortex strength
+    if (this.routes.jetRadius) {
+      this._ensureBase(conf, 'jetRadius');
+      if (conf.jetEnabled && this.routes.jetRadius.enable) {
+        const r = this.routes.jetRadius;
+        const base = this._bases.jetRadius;
+        if (base !== undefined) {
+          const delta = (shaped(r.source, r.curve) - 0.5) * r.gain * g * 0.4;
+          const target = clamp(base + delta, 2.0, 30.0);
+          this._setConf(conf, 'jetRadius', target);
+        }
+      } else {
+        this._restoreTowardsBase(conf, 'jetRadius');
+      }
+    }
+
     if (conf.vortexEnabled && this.routes.vortexStrength.enable) {
       const r = this.routes.vortexStrength;
       const v = conf.vortexStrength * 0.85 + shaped(r.source, r.curve) * r.gain * 0.15;
       conf.vortexStrength = clamp(v * g, 0, 4.0);
     }
 
-    // Noise
+    if (this.routes.vortexRadius) {
+      this._ensureBase(conf, 'vortexRadius');
+      if (conf.vortexEnabled && this.routes.vortexRadius.enable) {
+        const r = this.routes.vortexRadius;
+        const base = this._bases.vortexRadius;
+        if (base !== undefined) {
+          const delta = (shaped(r.source, r.curve) - 0.5) * r.gain * g * 0.4;
+          const target = clamp(base + delta, 4.0, 48.0);
+          this._setConf(conf, 'vortexRadius', target);
+        }
+      } else {
+        this._restoreTowardsBase(conf, 'vortexRadius');
+      }
+    }
+
     if (this.routes.noise.enable) {
       const r = this.routes.noise;
       const v = conf.noise * 0.9 + shaped(r.source, r.curve) * r.gain * 0.1;
       conf.noise = clamp(v * g, 0, 2.0);
     }
 
-    // APIC blend
     if (this.routes.apicBlend.enable) {
       const r = this.routes.apicBlend;
       const base = conf.apicBlend ?? 0.0;
@@ -93,7 +189,6 @@ export class AudioRouter {
       conf.apicBlend = target;
     }
 
-    // New volumetric fields
     if (conf.curlEnabled && this.routes.curlStrength.enable) {
       const r = this.routes.curlStrength;
       const base = conf.curlStrength ?? 0.5;
@@ -106,31 +201,117 @@ export class AudioRouter {
     }
     if (conf.waveEnabled && this.routes.waveAmplitude.enable) {
       const r = this.routes.waveAmplitude;
-      const src = r.source === 'beat' ? f.beat : ((r.source === 'fluxBass' || r.source === 'fluxMid' || r.source === 'fluxTreble') ? clamp((f[r.source] || 0) * 0.8, 0, 1) : get(r.source));
-      const shapedVal = this._shape(src, r.curve);
+      let srcVal;
+      if (r.source === 'beat') {
+        srcVal = Math.max(f.beat || 0, tempoConf > 0.25 ? tempoPulse : 0);
+      } else if (r.source === 'fluxBass' || r.source === 'fluxMid' || r.source === 'fluxTreble') {
+        srcVal = clamp((f[r.source] || 0) * 0.8, 0, 1);
+      } else {
+        srcVal = get(r.source);
+      }
+      const shapedVal = this._shape(srcVal, r.curve);
       const base = conf.waveAmplitude ?? 0.35;
       conf.waveAmplitude = clamp(base * 0.85 + shapedVal * r.gain * 0.15, 0.0, 2.0);
     }
 
-    // Viscosity (invert small range)
     if (this.routes.viscosity.enable) {
       const r = this.routes.viscosity;
       const delta = shaped(r.source, r.curve) * r.gain * 0.02;
       conf.dynamicViscosity = clamp((conf.dynamicViscosity ?? 0.1) + delta, 0.02, 0.6);
     }
 
-    // Environment micro-sway
+    if (this.routes.bloomStrength) {
+      this._ensureBase(conf, 'bloomStrength');
+      if (this.routes.bloomStrength.enable) {
+        const r = this.routes.bloomStrength;
+        const base = this._bases.bloomStrength;
+        if (base !== undefined) {
+          const delta = (shaped(r.source, r.curve) - 0.5) * r.gain * g * 0.5;
+          const target = clamp(base + delta, 0.0, 4.0);
+          this._setConf(conf, 'bloomStrength', target);
+        }
+      } else {
+        this._restoreTowardsBase(conf, 'bloomStrength');
+      }
+    }
+
+    if (this.routes.exposure) {
+      this._ensureBase(conf, 'exposure');
+      if (this.routes.exposure.enable) {
+        const r = this.routes.exposure;
+        const base = this._bases.exposure;
+        if (base !== undefined) {
+          const delta = (shaped(r.source, r.curve) - 0.5) * r.gain * g * 0.4;
+          const target = clamp(base + delta, 0.2, 1.8);
+          this._setConf(conf, 'exposure', target);
+        }
+      } else {
+        this._restoreTowardsBase(conf, 'exposure');
+      }
+    }
+
+    if (this.routes.postSaturation) {
+      this._ensureBase(conf, 'postSaturation');
+      if (this.routes.postSaturation.enable) {
+        const r = this.routes.postSaturation;
+        const base = this._bases.postSaturation;
+        if (base !== undefined) {
+          const delta = (shaped(r.source, r.curve) - 0.5) * r.gain * g * 0.45;
+          const target = clamp(base + delta, 0.3, 2.2);
+          this._setConf(conf, 'postSaturation', target);
+        }
+      } else if (!this.routes.colorSaturation || !this.routes.colorSaturation.enable) {
+        this._restoreTowardsBase(conf, 'postSaturation');
+      }
+    }
+
+    if (this.routes.postContrast) {
+      this._ensureBase(conf, 'postContrast');
+      if (this.routes.postContrast.enable) {
+        const r = this.routes.postContrast;
+        const base = this._bases.postContrast;
+        if (base !== undefined) {
+          const delta = (shaped(r.source, r.curve) - 0.5) * r.gain * g * 0.4;
+          const target = clamp(base + delta, 0.6, 1.8);
+          this._setConf(conf, 'postContrast', target);
+        }
+      } else {
+        this._restoreTowardsBase(conf, 'postContrast');
+      }
+    }
+
+    if (this.routes.dofAmount) {
+      this._ensureBase(conf, 'dofAmount');
+      if (conf.dofEnabled && this.routes.dofAmount.enable) {
+        const r = this.routes.dofAmount;
+        const base = this._bases.dofAmount;
+        if (base !== undefined) {
+          const delta = (shaped(r.source, r.curve) - 0.5) * r.gain * g * 0.4;
+          const target = clamp(base + delta, 0.4, 1.8);
+          this._setConf(conf, 'dofAmount', target);
+        }
+      } else {
+        this._restoreTowardsBase(conf, 'dofAmount');
+      }
+    }
+
     if (this.routes.envSway.enable && envBase) {
       const r = this.routes.envSway;
-      const sway = (get(r.source) * r.gain) * Math.sin(elapsed * 1.6) + (f.beat * 0.06);
+      const swayBase = get(r.source) * r.gain;
+      const sway = swayBase * tempoWave + (f.beat || 0) * 0.05;
       conf.bgRotY = envBase.bg + sway;
       conf.envRotY = envBase.env - sway * 0.8;
     }
 
-    // Color mode: audio saturation boost
-    if (this.routes.colorSaturation.enable && conf.colorMode === 'audio') {
-      // Keep using conf._audio* for renderers, router just ensures they're updated
-      // Additional hooks for postFX can be placed in postfx.js
+    if (this.routes.colorSaturation.enable && conf.colorMode === 'audio' && (!this.routes.postSaturation || !this.routes.postSaturation.enable)) {
+      this._ensureBase(conf, 'postSaturation');
+      const base = this._bases.postSaturation;
+      if (base !== undefined) {
+        const r = this.routes.colorSaturation;
+        const delta = (shaped(r.source, r.curve) - 0.5) * r.gain * g * 0.4;
+        const target = clamp(base + delta, 0.3, 2.2);
+        this._setConf(conf, 'postSaturation', target);
+      }
     }
   }
 }

--- a/src/conf.js
+++ b/src/conf.js
@@ -122,11 +122,19 @@ class Conf {
     audioMidGain = 1.0;
     audioTrebleGain = 1.0;
     audioBeatBoost = 1.0;
+    audioSubGain = 1.0;
+    audioPresenceGain = 1.0;
+    audioAirGain = 1.0;
+    audioTextureGain = 1.0;
+    audioColorTilt = 1.0;
     audioSource = 'mic'; // 'mic' | 'file'
     __onAudioUpload = null;
     // Runtime audio features (read-only; set by app)
     _audioLevel = 0.0; _audioBeat = 0.0; _audioBass = 0.0; _audioMid = 0.0; _audioTreble = 0.0;
-    _audioTempoPhase = 0.0; _audioTempoBpm = 0.0;
+    _audioLowMid = 0.0; _audioHighMid = 0.0;
+    _audioSub = 0.0; _audioPresence = 0.0; _audioAir = 0.0;
+    _audioTilt = 0.0; _audioRoughness = 0.0; _audioTransient = 0.0; _audioBrightness = 0.0;
+    _audioTempoPhase = 0.0; _audioTempoBpm = 0.0; _audioTempoConf = 0.0;
 
     // Post FX extras
     postFxEnabled = true;
@@ -691,6 +699,7 @@ class Conf {
             'orbitEnabled','orbitStrength','orbitRadius','orbitAxis',
             'waveEnabled','waveAmplitude','waveScale','waveSpeed','waveAxis',
             'audioEnabled','audioSource','audioSensitivity','audioAttack','audioRelease','audioBassGain','audioMidGain','audioTrebleGain','audioBeatBoost',
+            'audioSubGain','audioPresenceGain','audioAirGain','audioTextureGain','audioColorTilt',
             'vignetteEnabled','vignetteAmount','grainEnabled','grainAmount','chromaEnabled','chromaAmount','motionBlurEnabled','motionBlurAmount','postSaturation','postContrast','postLift','aaMode','aaAmount','gtaoEnabled','gtaoRadius','gtaoThickness','gtaoDistanceExponent','gtaoScale','gtaoSamples','gtaoResolutionScale','ssgiEnabled','ssgiSlices','ssgiSteps','ssgiIntensity','ssgiResolutionScale','ssgiDenoise','ssrEnabled','ssrOpacity','ssrMaxDistance','ssrThickness','ssrResolutionScale','ssrMetalness','lensEnabled','sensorWidth','focalLength','fStop','lensDriveFov','focusSmooth','dofQuality','apertureBlades','apertureRotation','aperturePetal','anamorphic'
         ];
         const out = {};

--- a/src/ui/audioPanel.js
+++ b/src/ui/audioPanel.js
@@ -48,6 +48,11 @@ export default class AudioPanel {
     audio.addBinding(this.conf, 'audioBassGain', { min: 0.0, max: 3.0, step: 0.05, label: 'bass gain' });
     audio.addBinding(this.conf, 'audioMidGain', { min: 0.0, max: 3.0, step: 0.05, label: 'mid gain' });
     audio.addBinding(this.conf, 'audioTrebleGain', { min: 0.0, max: 3.0, step: 0.05, label: 'treble gain' });
+    audio.addBinding(this.conf, 'audioSubGain', { min: 0.0, max: 3.0, step: 0.05, label: 'sub gain' });
+    audio.addBinding(this.conf, 'audioPresenceGain', { min: 0.0, max: 3.0, step: 0.05, label: 'presence gain' });
+    audio.addBinding(this.conf, 'audioAirGain', { min: 0.0, max: 3.0, step: 0.05, label: 'air gain' });
+    audio.addBinding(this.conf, 'audioTextureGain', { min: 0.2, max: 3.0, step: 0.05, label: 'texture gain' });
+    audio.addBinding(this.conf, 'audioColorTilt', { min: 0.2, max: 2.5, step: 0.05, label: 'tilt gain' });
     audio.addBinding(this.conf, 'audioBeatBoost', { min: 0.0, max: 3.0, step: 0.05, label: 'beat boost' });
 
     // Engine-level controls
@@ -82,8 +87,58 @@ export default class AudioPanel {
     diag.addBinding(this.conf, '_audioLevel', { readonly: true, label: 'level' });
     diag.addBinding(this.conf, '_audioBass', { readonly: true, label: 'bass' });
     diag.addBinding(this.conf, '_audioMid', { readonly: true, label: 'mid' });
+    diag.addBinding(this.conf, '_audioLowMid', { readonly: true, label: 'low mid' });
+    diag.addBinding(this.conf, '_audioHighMid', { readonly: true, label: 'high mid' });
     diag.addBinding(this.conf, '_audioTreble', { readonly: true, label: 'treble' });
     diag.addBinding(this.conf, '_audioBeat', { readonly: true, label: 'beat' });
+    diag.addBinding(this.conf, '_audioSub', { readonly: true, label: 'sub' });
+    diag.addBinding(this.conf, '_audioPresence', { readonly: true, label: 'presence' });
+    diag.addBinding(this.conf, '_audioAir', { readonly: true, label: 'air' });
+    diag.addBinding(this.conf, '_audioTilt', { readonly: true, label: 'tilt' });
+    diag.addBinding(this.conf, '_audioRoughness', { readonly: true, label: 'rough' });
+    diag.addBinding(this.conf, '_audioTransient', { readonly: true, label: 'trans' });
+    diag.addBinding(this.conf, '_audioBrightness', { readonly: true, label: 'bright' });
+    diag.addBinding(this.conf, '_audioTempoBpm', { readonly: true, label: 'tempo bpm' });
+    diag.addBinding(this.conf, '_audioTempoConf', { readonly: true, label: 'tempo conf' });
+
+    this._featureSmooth = {
+      level: { attack: 0.5, release: 0.2 },
+      bass: { attack: 0.5, release: 0.2 },
+      mid: { attack: 0.5, release: 0.2 },
+      treble: { attack: 0.5, release: 0.2 },
+      sub: { attack: 0.5, release: 0.25 },
+      presence: { attack: 0.45, release: 0.25 },
+      air: { attack: 0.45, release: 0.25 },
+      beat: { attack: 0.6, release: 0.2 },
+      tilt: { attack: 0.35, release: 0.25 },
+      roughness: { attack: 0.3, release: 0.45 },
+      transient: { attack: 0.7, release: 0.35 },
+      brightness: { attack: 0.45, release: 0.3 },
+    };
+    const envelopes = gui.addFolder({ title: 'feature envelopes', expanded: false });
+    const applySmooth = () => { try { this.engine.setFeatureSmoothing(this._featureSmooth); } catch {} };
+    const addEnv = (key, label) => {
+      const folder = envelopes.addFolder({ title: label, expanded: false });
+      folder.addBinding(this._featureSmooth[key], 'attack', { min: 0.05, max: 0.99, step: 0.01, label: 'attack' })
+        .on('change', applySmooth);
+      folder.addBinding(this._featureSmooth[key], 'release', { min: 0.05, max: 0.99, step: 0.01, label: 'release' })
+        .on('change', applySmooth);
+    };
+    [
+      ['level', 'level'],
+      ['bass', 'bass'],
+      ['mid', 'mid'],
+      ['treble', 'treble'],
+      ['sub', 'sub'],
+      ['presence', 'presence'],
+      ['air', 'air'],
+      ['beat', 'beat'],
+      ['tilt', 'tilt'],
+      ['roughness', 'roughness'],
+      ['transient', 'transient'],
+      ['brightness', 'brightness'],
+    ].forEach(([key, label]) => addEnv(key, label));
+    applySmooth();
 
     // File input
     audio.addBlade({ view: 'button', label: 'input', title: 'Choose Audio File' }).on('click', () => {
@@ -125,11 +180,23 @@ export default class AudioPanel {
       { text: 'level', value: 'level' },
       { text: 'beat', value: 'beat' },
       { text: 'bass', value: 'bass' },
+      { text: 'sub', value: 'sub' },
       { text: 'mid', value: 'mid' },
+      { text: 'low mid', value: 'lowMid' },
+      { text: 'high mid', value: 'highMid' },
       { text: 'treble', value: 'treble' },
-      { text: 'fluxBass', value: 'fluxBass' },
-      { text: 'fluxMid', value: 'fluxMid' },
-      { text: 'fluxTreble', value: 'fluxTreble' },
+      { text: 'presence', value: 'presence' },
+      { text: 'air', value: 'air' },
+      { text: 'tilt', value: 'tilt' },
+      { text: 'roughness', value: 'roughness' },
+      { text: 'transient', value: 'transient' },
+      { text: 'brightness', value: 'brightness' },
+      { text: 'tempo phase', value: 'tempoPhase01' },
+      { text: 'tempo pulse', value: 'tempoWave' },
+      { text: 'tempo conf', value: 'tempoConf' },
+      { text: 'flux bass', value: 'fluxBass' },
+      { text: 'flux mid', value: 'fluxMid' },
+      { text: 'flux treble', value: 'fluxTreble' },
     ];
     const routes = this.router?.getRoutes ? this.router.getRoutes() : {};
     const addRoute = (folder, key, label, min=0, max=2, step=0.01) => {
@@ -155,10 +222,17 @@ export default class AudioPanel {
     addRoute(phys, 'waveAmplitude', 'wave', 0, 3, 0.01);
     addRoute(phys, 'apicBlend', 'apic blend', 0, 1, 0.01);
     addRoute(phys, 'viscosity', 'viscosity', -1, 1, 0.01);
+    addRoute(phys, 'jetRadius', 'jet radius', 2, 30, 0.05);
+    addRoute(phys, 'vortexRadius', 'vortex radius', 4, 48, 0.05);
     const vis = routing.addFolder({ title: 'visuals', expanded: false });
     addRoute(vis, 'noise', 'noise');
     addRoute(vis, 'colorSaturation', 'color');
     addRoute(vis, 'envSway', 'env sway', 0, 0.2, 0.001);
+    addRoute(vis, 'bloomStrength', 'bloom', 0, 4, 0.01);
+    addRoute(vis, 'exposure', 'exposure', 0.2, 1.8, 0.01);
+    addRoute(vis, 'postSaturation', 'post sat', 0.3, 2.5, 0.01);
+    addRoute(vis, 'postContrast', 'contrast', 0.5, 2.0, 0.01);
+    addRoute(vis, 'dofAmount', 'dof amount', 0.2, 2.0, 0.01);
 
     this.gui = gui;
 
@@ -186,6 +260,13 @@ export default class AudioPanel {
         apicBlend: { source: 'level', gain: 0.35, curve: 1.4 },
         noise: { source: 'treble', gain: 0.35, curve: 1.0 },
         envSway: { source: 'level', gain: 0.06, curve: 1.0 },
+        jetRadius: { enable: true, source: 'sub', gain: 7.0, curve: 1.0 },
+        vortexRadius: { enable: true, source: 'presence', gain: 5.0, curve: 1.0 },
+        bloomStrength: { enable: true, source: 'presence', gain: 0.7, curve: 1.15 },
+        exposure: { enable: true, source: 'brightness', gain: 0.35, curve: 1.0 },
+        postSaturation: { enable: true, source: 'tilt', gain: 0.7, curve: 1.0 },
+        postContrast: { enable: false, source: 'transient', gain: 0.45, curve: 1.1 },
+        dofAmount: { enable: false, source: 'roughness', gain: 0.4, curve: 1.0 },
       },
       Swirl: {
         jetStrength: { source: 'bass', gain: 0.8, curve: 1.2, beatBoost: 0.4 },
@@ -196,6 +277,13 @@ export default class AudioPanel {
         apicBlend: { source: 'level', gain: 0.4, curve: 1.4 },
         noise: { source: 'treble', gain: 0.25, curve: 1.0 },
         envSway: { source: 'level', gain: 0.05, curve: 1.0 },
+        jetRadius: { enable: true, source: 'sub', gain: 4.5, curve: 1.1 },
+        vortexRadius: { enable: true, source: 'presence', gain: 6.2, curve: 1.05 },
+        bloomStrength: { enable: true, source: 'presence', gain: 0.5, curve: 1.0 },
+        exposure: { enable: false, source: 'brightness', gain: 0.3, curve: 1.0 },
+        postSaturation: { enable: true, source: 'tilt', gain: 0.6, curve: 1.1 },
+        postContrast: { enable: true, source: 'transient', gain: 0.5, curve: 1.0 },
+        dofAmount: { enable: true, source: 'roughness', gain: 0.45, curve: 1.0 },
       },
       Waves: {
         jetStrength: { source: 'fluxBass', gain: 0.9, curve: 1.1, beatBoost: 0.3 },
@@ -206,6 +294,13 @@ export default class AudioPanel {
         apicBlend: { source: 'level', gain: 0.3, curve: 1.2 },
         noise: { source: 'treble', gain: 0.3, curve: 1.0 },
         envSway: { source: 'level', gain: 0.05, curve: 1.0 },
+        jetRadius: { enable: true, source: 'fluxBass', gain: 5.5, curve: 1.0 },
+        vortexRadius: { enable: true, source: 'mid', gain: 4.2, curve: 1.0 },
+        bloomStrength: { enable: true, source: 'presence', gain: 0.45, curve: 1.0 },
+        exposure: { enable: true, source: 'brightness', gain: 0.3, curve: 1.0 },
+        postSaturation: { enable: true, source: 'tilt', gain: 0.55, curve: 1.0 },
+        postContrast: { enable: false, source: 'transient', gain: 0.35, curve: 1.0 },
+        dofAmount: { enable: true, source: 'roughness', gain: 0.35, curve: 1.0 },
       },
       Sparkle: {
         jetStrength: { source: 'fluxBass', gain: 1.1, curve: 1.3, beatBoost: 0.7 },
@@ -216,6 +311,13 @@ export default class AudioPanel {
         apicBlend: { source: 'level', gain: 0.35, curve: 1.5 },
         noise: { source: 'treble', gain: 0.4, curve: 1.0 },
         envSway: { source: 'level', gain: 0.06, curve: 1.0 },
+        jetRadius: { enable: true, source: 'fluxBass', gain: 6.4, curve: 1.1 },
+        vortexRadius: { enable: true, source: 'fluxMid', gain: 5.5, curve: 1.1 },
+        bloomStrength: { enable: true, source: 'presence', gain: 0.85, curve: 1.2 },
+        exposure: { enable: true, source: 'brightness', gain: 0.42, curve: 1.1 },
+        postSaturation: { enable: true, source: 'tilt', gain: 0.85, curve: 1.1 },
+        postContrast: { enable: true, source: 'transient', gain: 0.55, curve: 1.0 },
+        dofAmount: { enable: false, source: 'roughness', gain: 0.45, curve: 1.0 },
       },
     };
     const r = styles[name];


### PR DESCRIPTION
## Summary
- add a next-generation sound reactivity proposal detailing goals, pillars, and roadmap for the upgrade
- extend the audio engine with additional spectral features, transient metrics, and per-feature envelopes, wiring new signals into the app and router
- expand the audio router and panel with baseline-aware visual/physics routes, richer diagnostics, and per-feature smoothing controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d11b0c9188832795356d2eeb6950f0