### PR TITLE
Add modular Aurora refined build

### DIFF
--- a/ARCHITECTURE_REDESIGN_PROPOSAL.md
+++ b/ARCHITECTURE_REDESIGN_PROPOSAL.md
@@ -1,0 +1,138 @@
+# Aurora Architecture Redesign Proposal
+
+## Executive Summary
+
+The legacy Flow/WebGPU project delivers an impressive real-time liquid
+simulation, yet most orchestration lives in a single 400+ line `App` class.
+Rendering, audio reactivity, simulation control, and UI concerns are tightly
+coupled, which makes it hard to extend features, test isolated subsystems, or
+reason about performance bottlenecks. This proposal introduces **Aurora
+Refined**, a modular rebuild living inside `aurora-refined/`. The new structure
+splits responsibilities into explicit modules, formalises lifecycle boundaries,
+and establishes a predictable pipeline from boot to render. The design keeps all
+existing simulation and audio capabilities but exposes them through a cleaner,
+extendable API surface.
+
+## Current State Assessment
+
+| Area                | Challenges observed |
+| ------------------- | ------------------- |
+| **Lifecycle**       | `index.js` performs renderer creation, error handling, and animation loop wiring inline. Resizing, error rendering, and animation management are scattered. |
+| **Application core**| `src/app.js` manages configuration, simulation, audio, environment geometry, post-processing, UI listeners, and performance logic. Cross-cutting concerns (e.g. boundary uploads, audio normalisation) interleave in the render loop. |
+| **Configuration**   | `conf` is mutated across subsystems without clear ownership. Audio router, simulation uniforms, and UI panels all write into the same object during a single frame. |
+| **Testability**     | The monolithic update loop makes it difficult to unit-test or profile discrete behaviours. Side-effects (DOM mutations, router operations) cannot be exercised in isolation. |
+| **Extensibility**   | Adding a new post-processing pass or analytics hook requires editing the central `App` class and threading state manually. |
+
+## Architectural Goals
+
+1. **Modularity** – Decompose orchestration into well-named modules (`Environment`,
+   `Simulation`, `Audio`, `Effects`, `Interaction`, `Performance`).
+2. **Lifecycle clarity** – Standardise boot, resize, update, and teardown entry
+   points so that features can hook into predictable events.
+3. **UI separation** – Encapsulate DOM access for loading overlays and panels,
+   making it easier to swap UI shells or integrate with React/Svelte later.
+4. **Performance governance** – Preserve the automatic particle governor but
+   isolate its heuristics for future tuning or data collection.
+5. **Compatibility** – Continue to consume the proven simulation/audio
+   primitives without rewriting core maths or shaders.
+
+## Proposed Structure (Implemented in `aurora-refined/`)
+
+```
+aurora-refined/
+├── index.html           # Minimal shell with a LoadingOverlay-friendly veil
+├── main.js              # Entrypoint calling bootstrap()
+├── vite.config.js       # Vite config scoped to the new root
+├── src/
+│   ├── core/
+│   │   ├── Application.js   # High-level orchestrator
+│   │   ├── bootstrap.js     # Renderer creation + lifecycle wiring
+│   │   └── updateLoop.js    # RAF-driven async update loop helper
+│   ├── modules/
+│   │   ├── AudioModule.js
+│   │   ├── EnvironmentModule.js
+│   │   ├── EffectsModule.js
+│   │   ├── InteractionModule.js
+│   │   ├── PerformanceGovernor.js
+│   │   └── SimulationModule.js
+│   ├── ui/
+│   │   └── LoadingOverlay.js
+│   └── utils/
+│       └── math.js
+└── README.md
+```
+
+### Module Responsibilities
+
+- **EnvironmentModule** – Owns `Stage` lifecycle (camera, scene, lighting) and
+  stores the baseline environment rotation for audio sway calculations.
+- **SimulationModule** – Creates the MLS-MPM simulator, particle/point/glyph
+  renderers, and boundary geometry. Handles glass material sync, SDF updates,
+  and boundary upload ingestion without polluting the main loop.
+- **AudioModule** – Wraps `AudioEngine`, `AudioRouter`, and `AudioPanel`.
+  Normalises spectral bands, writes back to `conf._audio*`, and defers mapping to
+  the router with environment sway context.
+- **EffectsModule** – Manages post-processing (PostFX pipeline) and depth of
+  field (LensSystem). Provides motion vector updates and pointer-based autofocus.
+- **InteractionModule** – Centralises pointer raycasting, simulation ray updates,
+  and optional DOF autofocus, ensuring these concerns do not leak into
+  simulation logic.
+- **PerformanceGovernor** – Keeps the adaptive particle-count governor focused
+  and inspectable, ready for future telemetry.
+- **LoadingOverlay** – Offers a declarative progress/error API for bootstrap,
+  replacing ad-hoc DOM manipulation.
+
+## Pipeline Overview
+
+1. **Bootstrap** (`bootstrap.js`)
+   - Validates WebGPU support, creates the renderer, and mounts the canvas.
+   - Instantiates `Application`, feeding a shared progress callback to the
+     loading overlay.
+   - Subscribes to `resize` and starts the asynchronous `UpdateLoop`.
+
+2. **Initialisation** (`Application.init`)
+   - `conf.init()` primes configuration defaults.
+   - Environment, simulation, audio, and effects modules initialise sequentially
+     with explicit progress milestones.
+   - Interaction module attaches pointer listeners; performance governor begins
+     tracking frame statistics.
+
+3. **Per-frame Update** (`Application.update`)
+   - `conf.begin()`/`conf.end()` bracket the frame.
+   - Stage update → renderer visibility selection → audio feature extraction →
+     simulation step → post-processing update → render dispatch.
+   - Performance governor adjusts `conf.particles` when FPS deviates from the
+     configured range.
+
+## Configuration & Data Flow
+
+- `conf` remains the canonical shared configuration object, but only the
+  relevant module mutates its slice. For instance, `AudioModule` is solely
+  responsible for `_audio*` fields, while `SimulationModule` handles SDF
+  uniforms.
+- Router application now receives a well-typed payload generated inside
+  `AudioModule`, reducing duplicate logic across modules.
+- Interaction and effects modules collaborate to translate pointer movement
+  into both simulation rays and DOF updates, eliminating repeated coordinate
+  conversion code.
+
+## Migration & Follow-up Tasks
+
+1. **Unit testing** – With modules isolated, introduce targeted tests (e.g.
+   verifying audio normalisation or performance governor thresholds).
+2. **Type safety** – Adopt TypeScript or JSDoc typings in `aurora-refined/` to
+   formally document module contracts.
+3. **Configuration bridge** – Gradually move from the shared `conf` singleton to
+   an evented settings service, enabling undo/redo and preset comparison.
+4. **Telemetry hooks** – Expose frame timing data from `PerformanceGovernor`
+   through a lightweight observer API for analytics dashboards.
+5. **UI re-skin** – Replace the bespoke DOM overlay with a component framework
+   (React, Svelte) now that rendering and state are decoupled.
+
+## Conclusion
+
+The refactored structure in `aurora-refined/` proves that the Flow experience
+can run on top of a maintainable, modular foundation. The proposal lays out the
+paths to extend the architecture further—introducing automated tests, typed
+configuration, and richer tooling—without sacrificing the artistry of the
+simulation itself.

--- a/aurora-refined/README.md
+++ b/aurora-refined/README.md
@@ -1,0 +1,30 @@
+# Aurora Refined
+
+This folder contains a modular rebuild of the original Flow WebGPU experience.
+It keeps the simulation and rendering capabilities of the legacy project while
+restructuring the orchestration into explicit, testable modules.
+
+## Highlights
+
+- **Lifecycle isolation** – The `Application` class delegates to focused
+  modules for environment, simulation, audio, effects, interaction, and
+  performance governance.
+- **Composable pipeline** – Rendering, simulation updates, audio reactivity,
+  and post-processing now flow through a predictable loop managed by
+  `UpdateLoop`.
+- **UI infrastructure** – Bootstrapping concerns (loading veil and error
+  handling) live in `LoadingOverlay`, avoiding scattered DOM queries.
+- **Compatibility** – The module layer reuses the battle-tested simulation,
+  audio, and UI building blocks from the legacy codebase via relative imports.
+
+Run the project with:
+
+```bash
+npm run dev:refined
+```
+
+Build the project with:
+
+```bash
+npm run build:refined
+```

--- a/aurora-refined/index.html
+++ b/aurora-refined/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, height=device-height, interactive-widget=resizes-content, shrink-to-fit=0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"
+    />
+    <title>Aurora Refined — WebGPU Liquid Instrument</title>
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        position: relative;
+        overflow: hidden;
+        background-color: black;
+      }
+
+      #app-root {
+        width: 100%;
+        height: 100%;
+        display: block;
+        position: relative;
+      }
+
+      #loading-veil {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        background: radial-gradient(circle at 30% 30%, rgba(48, 68, 92, 0.75), rgba(12, 16, 22, 0.92));
+        color: #dce3f3;
+        font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        opacity: 1;
+        transition: opacity 0.8s ease;
+        pointer-events: none;
+      }
+
+      #progress-track {
+        width: 240px;
+        height: 6px;
+        background-color: rgba(255, 255, 255, 0.18);
+        border-radius: 999px;
+        overflow: hidden;
+      }
+
+      #progress-value {
+        height: 100%;
+        width: 0;
+        background: linear-gradient(90deg, #68d5ff 0%, #c084fc 100%);
+        transition: width 0.25s ease;
+      }
+
+      #error-message {
+        max-width: 320px;
+        text-align: center;
+        font-size: 14px;
+        letter-spacing: 0.01em;
+        visibility: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app-root">
+      <div id="loading-veil">
+        <div id="progress-track"><div id="progress-value"></div></div>
+        <div id="error-message"></div>
+      </div>
+    </div>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/aurora-refined/main.js
+++ b/aurora-refined/main.js
@@ -1,0 +1,6 @@
+import { bootstrap } from './src/core/bootstrap.js';
+
+bootstrap().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('[aurora-refined] bootstrap failed', error);
+});

--- a/aurora-refined/src/core/Application.js
+++ b/aurora-refined/src/core/Application.js
@@ -1,0 +1,87 @@
+import { conf } from '../../../src/conf.js';
+
+import { EnvironmentModule } from '../modules/EnvironmentModule.js';
+import { SimulationModule } from '../modules/SimulationModule.js';
+import { AudioModule } from '../modules/AudioModule.js';
+import { EffectsModule } from '../modules/EffectsModule.js';
+import { InteractionModule } from '../modules/InteractionModule.js';
+import { PerformanceGovernor } from '../modules/PerformanceGovernor.js';
+
+export class Application {
+  constructor(renderer) {
+    this.renderer = renderer;
+
+    this.environment = null;
+    this.simulation = null;
+    this.audio = null;
+    this.effects = null;
+    this.interaction = null;
+    this.performance = null;
+
+    this._envBase = null;
+  }
+
+  async init(progressCallback = () => {}) {
+    conf.init();
+
+    this.environment = new EnvironmentModule(this.renderer);
+    await this.environment.init(progressCallback);
+    this._envBase = this.environment.getEnvironmentBase();
+
+    await progressCallback(0.5);
+
+    this.simulation = new SimulationModule(this.renderer, this.environment.getStage());
+    await this.simulation.init();
+
+    this.audio = new AudioModule();
+    await this.audio.init();
+
+    this.effects = new EffectsModule(this.renderer);
+    await this.effects.init(this.environment.getStage());
+
+    this.interaction = new InteractionModule(
+      this.environment.getStage(),
+      this.simulation,
+      this.effects,
+      this.renderer.domElement,
+    );
+    this.interaction.bind();
+
+    this.performance = new PerformanceGovernor();
+
+    await progressCallback(1.0, 100);
+  }
+
+  resize(width, height) {
+    this.environment?.resize(width, height);
+    this.effects?.resize(width, height);
+  }
+
+  async update(delta, elapsed) {
+    conf.begin();
+
+    this.environment?.update(delta, elapsed);
+    const stage = this.environment?.getStage();
+
+    if (this.simulation) {
+      this.simulation.setRenderMode(conf.renderMode || 'surface');
+      this.simulation.updateRenderers();
+    }
+
+    await this.audio?.update(delta, elapsed, this._envBase);
+
+    await this.simulation?.updateSimulation(delta, elapsed);
+
+    if (this.effects && stage) {
+      this.effects.updateFromConfig(conf);
+      this.effects.updateMotion(stage);
+      await this.effects.render(stage, conf);
+    } else if (stage) {
+      await this.renderer.renderAsync(stage.scene, stage.camera);
+    }
+
+    conf.end();
+
+    this.performance?.update(delta);
+  }
+}

--- a/aurora-refined/src/core/bootstrap.js
+++ b/aurora-refined/src/core/bootstrap.js
@@ -1,0 +1,55 @@
+import * as THREE from 'three/webgpu';
+
+import LoadingOverlay from '../ui/LoadingOverlay.js';
+import { Application } from './Application.js';
+import { UpdateLoop } from './updateLoop.js';
+
+THREE.ColorManagement.enabled = true;
+
+function createRenderer() {
+  const renderer = new THREE.WebGPURenderer({});
+  renderer.setPixelRatio(window.devicePixelRatio);
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  return renderer;
+}
+
+export async function bootstrap() {
+  const overlay = new LoadingOverlay();
+
+  try {
+    if (!navigator.gpu) {
+      overlay.showError('Your device does not support WebGPU.');
+      return;
+    }
+
+    const renderer = createRenderer();
+    await renderer.init();
+
+    if (!renderer.backend.isWebGPUBackend) {
+      overlay.showError("Couldn't initialize WebGPU. Make sure WebGPU is supported by your browser.");
+      return;
+    }
+
+    const container = document.getElementById('app-root');
+    container.appendChild(renderer.domElement);
+
+    const application = new Application(renderer);
+    await application.init((fraction, delay) => overlay.updateProgress(fraction, delay));
+
+    const handleResize = () => {
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      application.resize(window.innerWidth, window.innerHeight);
+    };
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    overlay.fadeOut();
+
+    const loop = new UpdateLoop((delta, elapsed) => application.update(delta, elapsed));
+    loop.start();
+  } catch (error) {
+    overlay.showError('An unexpected error occurred while loading Aurora.');
+    throw error;
+  }
+}

--- a/aurora-refined/src/core/updateLoop.js
+++ b/aurora-refined/src/core/updateLoop.js
@@ -1,0 +1,49 @@
+import * as THREE from 'three/webgpu';
+
+/**
+ * UpdateLoop standardises the animation frame lifecycle for the application.
+ * It exposes start/stop controls and guarantees delta/elapsed timestamps that
+ * mirror the behaviour of Three.js' legacy clock usage.
+ */
+export class UpdateLoop {
+  constructor(step) {
+    this.step = step;
+    this.clock = new THREE.Clock();
+    this.running = false;
+    this._frameHandle = null;
+    this._tick = this._tick.bind(this);
+  }
+
+  start() {
+    if (this.running) return;
+    this.running = true;
+    this.clock.start();
+    this._frameHandle = requestAnimationFrame(this._tick);
+  }
+
+  stop() {
+    this.running = false;
+    if (this._frameHandle) {
+      cancelAnimationFrame(this._frameHandle);
+      this._frameHandle = null;
+    }
+  }
+
+  async _tick() {
+    if (!this.running) return;
+
+    const delta = this.clock.getDelta();
+    const elapsed = this.clock.getElapsedTime();
+
+    try {
+      await this.step(delta, elapsed);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('[aurora-refined] update loop error', error);
+      this.stop();
+      return;
+    }
+
+    this._frameHandle = requestAnimationFrame(this._tick);
+  }
+}

--- a/aurora-refined/src/modules/AudioModule.js
+++ b/aurora-refined/src/modules/AudioModule.js
@@ -1,0 +1,188 @@
+import AudioEngine from '../../../src/audio/audioEngine.js';
+import { AudioRouter } from '../../../src/audio/router.js';
+import AudioPanel from '../../../src/ui/audioPanel.js';
+import { conf } from '../../../src/conf.js';
+
+import { clamp01 } from '../utils/math.js';
+
+export class AudioModule {
+  constructor() {
+    this.engine = new AudioEngine();
+    this.router = new AudioRouter();
+    this.panel = null;
+    this._started = false;
+
+    if (conf.registerRouter) {
+      conf.registerRouter(this.router);
+    }
+  }
+
+  async init() {
+    this.panel = new AudioPanel(this.engine, conf, this.router);
+    this.panel.init('bottom-right');
+  }
+
+  async update(delta, elapsed, environmentBase) {
+    if (!conf.audioEnabled) {
+      this._resetState(environmentBase);
+      return;
+    }
+
+    try {
+      await this._ensureSource();
+      this.engine.setSmoothing(conf.audioAttack, conf.audioRelease);
+      const features = this.engine.update(delta);
+      const mapped = this._mapFeatures(features);
+      this._writeBack(mapped);
+      this.router.apply(this._routerPayload(features, mapped), conf, elapsed, environmentBase);
+    } catch (error) {
+      // The legacy application silently swallowed audio exceptions.
+      // Keeping the behaviour avoids interrupting rendering on transient mic failures.
+    }
+  }
+
+  async _ensureSource() {
+    if (this._started) return;
+    if (conf.audioSource === 'mic') {
+      await this.engine.connectMic();
+    }
+    this._started = true;
+  }
+
+  _mapFeatures(features) {
+    const sens = conf.audioSensitivity || 1;
+    const bassGain = conf.audioBassGain * sens;
+    const midGain = conf.audioMidGain * sens;
+    const trebleGain = conf.audioTrebleGain * sens;
+
+    return {
+      level: clamp01(features.level * sens),
+      beat: clamp01(features.beat * conf.audioBeatBoost),
+      bass: clamp01(features.bass * bassGain),
+      mid: clamp01(features.mid * midGain),
+      treble: clamp01(features.treble * trebleGain),
+      sub: clamp01((features.sub ?? features.bass) * bassGain),
+      lowMid: clamp01((features.lowMid ?? features.mid) * midGain),
+      highMid: clamp01((features.highMid ?? features.mid) * midGain),
+      presence: clamp01((features.presence ?? features.treble) * trebleGain),
+      air: clamp01((features.air ?? features.treble) * trebleGain),
+      flux: Math.max(0, features.flux || 0),
+      fluxNorm: clamp01(features.fluxNorm ?? 0),
+      dynamics: clamp01(features.dynamics ?? 0),
+      crest: clamp01(features.crest ?? 0),
+      rms: clamp01(features.rms ?? 0),
+      loudness: clamp01(features.loudness ?? features.level ?? 0),
+      tilt: clamp01(features.tilt ?? 0.5),
+      stereo: clamp01(features.stereo ?? 0.5),
+      stereoSigned: Math.max(-1, Math.min(1, features.stereoSigned ?? 0)),
+      stereoWidth: clamp01(features.stereoWidth ?? 0),
+      dominant: clamp01(features.dominant ?? 0),
+      beatConfidence: clamp01(features.beatConfidence ?? 0),
+      tempoPhase: features.tempoPhase01 || 0,
+      tempoBpm: features.tempoBpm || 0,
+      tempoConf: features.tempoConf || 0,
+      tempoNorm: clamp01(features.tempoNorm ?? 0),
+    };
+  }
+
+  _writeBack(mapped) {
+    conf._audioLevel = mapped.level;
+    conf._audioBeat = mapped.beat;
+    conf._audioBass = mapped.bass;
+    conf._audioMid = mapped.mid;
+    conf._audioTreble = mapped.treble;
+    conf._audioSub = mapped.sub;
+    conf._audioLowMid = mapped.lowMid;
+    conf._audioHighMid = mapped.highMid;
+    conf._audioPresence = mapped.presence;
+    conf._audioAir = mapped.air;
+    conf._audioFlux = mapped.flux;
+    conf._audioFluxNorm = mapped.fluxNorm;
+    conf._audioDynamics = mapped.dynamics;
+    conf._audioCrest = mapped.crest;
+    conf._audioRms = mapped.rms;
+    conf._audioLoudness = mapped.loudness;
+    conf._audioTilt = mapped.tilt;
+    conf._audioStereo = mapped.stereo;
+    conf._audioStereoSigned = mapped.stereoSigned;
+    conf._audioStereoWidth = mapped.stereoWidth;
+    conf._audioDominant = mapped.dominant;
+    conf._audioBeatConfidence = mapped.beatConfidence;
+    conf._audioTempoPhase = mapped.tempoPhase;
+    conf._audioTempoBpm = mapped.tempoBpm;
+    conf._audioTempoConf = mapped.tempoConf;
+    conf._audioTempoNorm = mapped.tempoNorm;
+  }
+
+  _routerPayload(features, mapped) {
+    return {
+      level: mapped.level,
+      beat: mapped.beat,
+      bass: mapped.bass,
+      mid: mapped.mid,
+      treble: mapped.treble,
+      sub: mapped.sub,
+      lowMid: mapped.lowMid,
+      highMid: mapped.highMid,
+      presence: mapped.presence,
+      air: mapped.air,
+      centroid: features.centroid,
+      tilt: features.tilt,
+      tiltSigned: features.tiltSigned,
+      flux: features.flux,
+      fluxNorm: features.fluxNorm,
+      fluxBass: features.fluxBass,
+      fluxMid: features.fluxMid,
+      fluxTreble: features.fluxTreble,
+      beatConfidence: features.beatConfidence,
+      rms: features.rms,
+      loudness: features.loudness,
+      crest: features.crest,
+      dynamics: features.dynamics,
+      stereo: features.stereo,
+      stereoSigned: features.stereoSigned,
+      stereoWidth: features.stereoWidth,
+      dominant: features.dominant,
+      tempoBpm: features.tempoBpm,
+      tempoPhase01: features.tempoPhase01,
+      tempoConf: features.tempoConf,
+      tempoNorm: features.tempoNorm,
+      tempoPulse: features.tempoPulse,
+      bandEnergies: features.bandEnergies,
+    };
+  }
+
+  _resetState(environmentBase) {
+    conf._audioLevel = 0;
+    conf._audioBeat = 0;
+    conf._audioBass = 0;
+    conf._audioMid = 0;
+    conf._audioTreble = 0;
+    conf._audioSub = 0;
+    conf._audioLowMid = 0;
+    conf._audioHighMid = 0;
+    conf._audioPresence = 0;
+    conf._audioAir = 0;
+    conf._audioFlux = 0;
+    conf._audioFluxNorm = 0;
+    conf._audioDynamics = 0;
+    conf._audioCrest = 0;
+    conf._audioRms = 0;
+    conf._audioLoudness = 0;
+    conf._audioTilt = 0.5;
+    conf._audioStereo = 0.5;
+    conf._audioStereoSigned = 0;
+    conf._audioStereoWidth = 0;
+    conf._audioDominant = 0;
+    conf._audioBeatConfidence = 0;
+    conf._audioTempoPhase = 0;
+    conf._audioTempoBpm = 0;
+    conf._audioTempoConf = 0;
+    conf._audioTempoNorm = 0;
+
+    if (environmentBase) {
+      conf.bgRotY = environmentBase.bg;
+      conf.envRotY = environmentBase.env;
+    }
+  }
+}

--- a/aurora-refined/src/modules/EffectsModule.js
+++ b/aurora-refined/src/modules/EffectsModule.js
@@ -1,0 +1,52 @@
+import PostFX from '../../../src/postfx.js';
+import LensSystem from '../../../src/lens/LensSystem.js';
+
+export class EffectsModule {
+  constructor(renderer) {
+    this.renderer = renderer;
+    this.postFX = null;
+    this.lens = null;
+    this._previousCameraPosition = null;
+  }
+
+  async init(stage) {
+    this.postFX = new PostFX(this.renderer);
+    await this.postFX.init(stage);
+    this.lens = new LensSystem(stage, this.postFX);
+    this._previousCameraPosition = stage.camera.position.clone();
+  }
+
+  resize(width, height) {
+    if (this.postFX) this.postFX.resize(width, height);
+  }
+
+  updateFromConfig(conf) {
+    if (this.postFX) this.postFX.updateFromConf(conf);
+    if (this.lens) this.lens.update();
+  }
+
+  updateMotion(stage) {
+    if (!this.postFX || !stage?.camera) return;
+    if (!this._previousCameraPosition) {
+      this._previousCameraPosition = stage.camera.position.clone();
+    }
+
+    this.postFX.updateMotionDirection(stage.camera, this._previousCameraPosition);
+    this._previousCameraPosition.copy(stage.camera.position);
+  }
+
+  async render(stage, conf) {
+    if (conf.postFxEnabled && this.postFX) {
+      await this.postFX.renderAsync();
+      return;
+    }
+
+    await this.renderer.renderAsync(stage.scene, stage.camera);
+  }
+
+  autoFocus(distance) {
+    if (this.lens && distance != null) {
+      this.lens.focusFromPointer(distance);
+    }
+  }
+}

--- a/aurora-refined/src/modules/EnvironmentModule.js
+++ b/aurora-refined/src/modules/EnvironmentModule.js
@@ -1,0 +1,38 @@
+import Stage from '../../../src/stage.js';
+import { conf } from '../../../src/conf.js';
+
+/**
+ * EnvironmentModule wraps the legacy Stage orchestration, keeping camera and
+ * scene lifecycle isolated from the rest of the application.
+ */
+export class EnvironmentModule {
+  constructor(renderer) {
+    this.renderer = renderer;
+    this.stage = null;
+    this.environmentBase = null;
+  }
+
+  async init(progressCallback) {
+    this.stage = new Stage(this.renderer);
+    await this.stage.init(progressCallback);
+    this.environmentBase = { bg: conf.bgRotY, env: conf.envRotY };
+  }
+
+  getStage() {
+    return this.stage;
+  }
+
+  getEnvironmentBase() {
+    return this.environmentBase;
+  }
+
+  resize(width, height) {
+    if (!this.stage) return;
+    this.stage.resize(width, height);
+  }
+
+  update(delta, elapsed) {
+    if (!this.stage) return;
+    this.stage.update(delta, elapsed);
+  }
+}

--- a/aurora-refined/src/modules/InteractionModule.js
+++ b/aurora-refined/src/modules/InteractionModule.js
@@ -1,0 +1,75 @@
+import * as THREE from 'three/webgpu';
+
+import { conf } from '../../../src/conf.js';
+
+const BASE_SIM_SCALE = 1 / 64;
+
+export class InteractionModule {
+  constructor(stage, simulation, effects, domElement) {
+    this.stage = stage;
+    this.simulation = simulation;
+    this.effects = effects;
+    this.domElement = domElement;
+
+    this.raycaster = new THREE.Raycaster();
+    this.pointer = new THREE.Vector2();
+
+    this._onPointerMove = this._onPointerMove.bind(this);
+  }
+
+  bind() {
+    if (!this.domElement) return;
+    this.domElement.addEventListener('pointermove', this._onPointerMove);
+  }
+
+  dispose() {
+    if (!this.domElement) return;
+    this.domElement.removeEventListener('pointermove', this._onPointerMove);
+  }
+
+  _onPointerMove(event) {
+    if (!this.stage?.camera) return;
+
+    const width = window.innerWidth || this.domElement.clientWidth;
+    const height = window.innerHeight || this.domElement.clientHeight;
+
+    this.pointer.x = (event.clientX / width) * 2 - 1;
+    this.pointer.y = -(event.clientY / height) * 2 + 1;
+
+    this.raycaster.setFromCamera(this.pointer, this.stage.camera);
+
+    const normal = new THREE.Vector3();
+    this.stage.camera.getWorldDirection(normal);
+
+    const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(normal, new THREE.Vector3(0, 0, 0));
+    const intersect = new THREE.Vector3();
+    this.raycaster.ray.intersectPlane(plane, intersect);
+    if (!intersect) return;
+
+    const worldScale = BASE_SIM_SCALE * (conf.worldScale || 1);
+    const zScale = conf.zScale || 0.4;
+
+    const worldToSim = (vector) => {
+      const out = vector.clone().divideScalar(worldScale);
+      out.z /= zScale;
+      out.add(new THREE.Vector3(32, 32, 32));
+      return out;
+    };
+
+    const originSim = worldToSim(this.raycaster.ray.origin);
+    const posSim = worldToSim(intersect);
+
+    const dirSim = this.raycaster.ray.direction.clone();
+    dirSim.divideScalar(worldScale);
+    dirSim.z /= zScale;
+    dirSim.normalize();
+
+    this.simulation.setMouseRay(originSim, dirSim, posSim);
+
+    if (conf.lensEnabled && (conf.lensFocusMode || 'auto') === 'auto') {
+      const camSpace = intersect.clone().applyMatrix4(this.stage.camera.matrixWorldInverse);
+      const viewDist = Math.abs(camSpace.z);
+      this.effects.autoFocus(viewDist);
+    }
+  }
+}

--- a/aurora-refined/src/modules/PerformanceGovernor.js
+++ b/aurora-refined/src/modules/PerformanceGovernor.js
@@ -1,0 +1,42 @@
+import { conf } from '../../../src/conf.js';
+
+export class PerformanceGovernor {
+  constructor() {
+    this._accumulator = 0;
+    this._frames = 0;
+    this._fps = 60;
+    this._lastAdjust = 0;
+  }
+
+  update(delta) {
+    this._accumulator += delta;
+    this._frames += 1;
+
+    if (this._accumulator >= 0.5) {
+      const fps = this._frames / this._accumulator;
+      this._fps = this._fps * 0.6 + fps * 0.4;
+      this._accumulator = 0;
+      this._frames = 0;
+    }
+
+    if (!conf.autoPerf) return;
+
+    const now = performance.now() / 1000;
+    if (now - this._lastAdjust <= 1.2) return;
+
+    if (this._fps < conf.perfMinFps && conf.particles > 4096) {
+      conf.particles = Math.max(4096, conf.particles - conf.perfStep);
+      conf.updateParams();
+      if (conf.gui) conf.gui.refresh();
+      this._lastAdjust = now;
+      return;
+    }
+
+    if (this._fps > conf.perfMaxFps && conf.particles + conf.perfStep <= conf.maxParticles) {
+      conf.particles = Math.min(conf.maxParticles, conf.particles + conf.perfStep);
+      conf.updateParams();
+      if (conf.gui) conf.gui.refresh();
+      this._lastAdjust = now;
+    }
+  }
+}

--- a/aurora-refined/src/modules/SimulationModule.js
+++ b/aurora-refined/src/modules/SimulationModule.js
@@ -1,0 +1,251 @@
+import * as THREE from 'three/webgpu';
+import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+
+import { conf } from '../../../src/conf.js';
+import BackgroundGeometry from '../../../src/backgroundGeometry.js';
+import MlsMpmSimulator from '../../../src/mls-mpm/mlsMpmSimulator.js';
+import ParticleRenderer from '../../../src/mls-mpm/particleRenderer.js';
+import PointRenderer from '../../../src/mls-mpm/pointRenderer.js';
+import GlyphRenderer from '../../../src/mls-mpm/glyphRenderer.js';
+
+const SIM_SCALE = 1 / 64;
+
+export class SimulationModule {
+  constructor(renderer, stage) {
+    this.renderer = renderer;
+    this.stage = stage;
+
+    this.simulator = null;
+    this.particleRenderer = null;
+    this.pointRenderer = null;
+    this.glyphRenderer = null;
+
+    this.background = null;
+    this.boundaryMesh = null;
+
+    this._glassSync = null;
+    this._shapeSync = null;
+  }
+
+  async init() {
+    this.simulator = new MlsMpmSimulator(this.renderer);
+    await this.simulator.init();
+
+    this.particleRenderer = new ParticleRenderer(this.simulator);
+    this.pointRenderer = new PointRenderer(this.simulator);
+    this.glyphRenderer = new GlyphRenderer(this.simulator);
+
+    this.stage.scene.add(this.particleRenderer.object);
+    this.stage.scene.add(this.pointRenderer.object);
+    if (this.glyphRenderer) this.stage.scene.add(this.glyphRenderer.object);
+
+    this.background = new BackgroundGeometry();
+    await this.background.init();
+    this.stage.scene.add(this.background.object);
+    this.boundaryMesh = this.background.glass;
+
+    this._startGlassSync();
+    this._startShapeSync();
+    this._registerBoundaryUpload();
+  }
+
+  _startGlassSync() {
+    if (this._glassSync) window.clearInterval(this._glassSync);
+    const updateGlass = () => {
+      if (!this.background) return;
+      this.background.setGlassParams({
+        ior: conf.glassIor,
+        thickness: conf.glassThickness,
+        roughness: conf.glassRoughness,
+        dispersion: conf.glassDispersion,
+        attenuationDistance: conf.glassAttenuationDistance,
+        attenuationColor: conf.glassAttenuationColor,
+      });
+    };
+
+    updateGlass();
+    this._glassSync = window.setInterval(updateGlass, 150);
+  }
+
+  _startShapeSync() {
+    if (this._shapeSync) window.clearInterval(this._shapeSync);
+    const updateShape = () => {
+      if (!this.background || !this.simulator) return;
+
+      if (this.background.object) {
+        this.background.object.visible = !!conf.boundariesEnabled;
+      }
+
+      this.background.setShape(conf.boundaryShape);
+      this._syncSimulationSdf();
+    };
+
+    updateShape();
+    this._shapeSync = window.setInterval(updateShape, 200);
+  }
+
+  _syncSimulationSdf() {
+    const uniforms = this.simulator?.uniforms;
+    if (!uniforms) return;
+
+    const mesh = this.background?.glass;
+    const shrink = conf.collisionShrink || 0.98;
+
+    if (conf.boundariesEnabled && conf.boundaryShape === 'dodeca') {
+      uniforms.sdfSphere.value = 2;
+      if (mesh && mesh.geometry) {
+        if (!mesh.geometry.boundingSphere) mesh.geometry.computeBoundingSphere();
+        const worldRadius = mesh.geometry.boundingSphere.radius;
+        const gridRadius = worldRadius / SIM_SCALE;
+        uniforms.sdfRadius.value = gridRadius * 0.8 * shrink;
+        uniforms.sdfCenter.value.set(
+          uniforms.gridSize.value.x * 0.5,
+          uniforms.gridSize.value.y * 0.5,
+          uniforms.gridSize.value.z * 0.5,
+        );
+      }
+    } else if (conf.boundariesEnabled && conf.boundaryShape === 'sphere') {
+      uniforms.sdfSphere.value = 1;
+      if (mesh && mesh.geometry) {
+        if (!mesh.geometry.boundingSphere) mesh.geometry.computeBoundingSphere();
+        const worldRadius = mesh.geometry.boundingSphere.radius;
+        const gridRadius = worldRadius / SIM_SCALE;
+        uniforms.sdfRadius.value = gridRadius * shrink;
+        uniforms.sdfCenter.value.set(
+          uniforms.gridSize.value.x * 0.5,
+          uniforms.gridSize.value.y * 0.5,
+          uniforms.gridSize.value.z * 0.5,
+        );
+      }
+    } else {
+      if ((conf.borderMode || 'bounce') === 'bounce') {
+        uniforms.sdfSphere.value = 0;
+      } else {
+        uniforms.sdfSphere.value = 3;
+      }
+    }
+  }
+
+  _registerBoundaryUpload() {
+    if (!conf.registerBoundaryUpload) return;
+
+    conf.registerBoundaryUpload(() => {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = '.obj,.glb,.gltf,.fbx,.ply,.stl';
+
+      input.onchange = async () => {
+        const file = input.files && input.files[0];
+        if (!file) return;
+
+        try {
+          const ext = file.name.split('.').pop().toLowerCase();
+          const mesh = await this._loadBoundaryMesh(file, ext);
+          if (!mesh) return;
+
+          mesh.castShadow = true;
+          mesh.receiveShadow = true;
+
+          if (this.background.glass.parent) {
+            this.background.glass.parent.remove(this.background.glass);
+          }
+
+          this.background.glass = mesh;
+          this.boundaryMesh = mesh;
+          this.background.object.add(mesh);
+
+          this._startGlassSync();
+          this._syncSimulationSdf();
+
+          conf.boundaryShape = 'sphere';
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('[aurora-refined] boundary upload failed', error);
+        }
+      };
+
+      input.click();
+    });
+  }
+
+  async _loadBoundaryMesh(file, extension) {
+    const ext = extension || '';
+
+    if (ext === 'obj') {
+      const text = await file.text();
+      const { OBJLoader } = await import('three/examples/jsm/loaders/OBJLoader.js');
+      const obj = new OBJLoader().parse(text);
+      const geo = BufferGeometryUtils.mergeVertices(obj.children[0].geometry);
+      return new THREE.Mesh(geo, this.background.glass.material);
+    }
+
+    if (ext === 'gltf' || ext === 'glb') {
+      const { GLTFLoader } = await import('three/examples/jsm/loaders/GLTFLoader.js');
+      const loader = new GLTFLoader();
+      const arrayBuffer = await file.arrayBuffer();
+      const gltf = await new Promise((resolve, reject) => loader.parse(arrayBuffer, '', resolve, reject));
+      const mesh = gltf.scene.getObjectByProperty('type', 'Mesh') || gltf.scene.children.find((c) => c.isMesh);
+      const geo = mesh.geometry;
+      return new THREE.Mesh(geo, this.background.glass.material);
+    }
+
+    if (ext === 'ply') {
+      const { PLYLoader } = await import('three/examples/jsm/loaders/PLYLoader.js');
+      const loader = new PLYLoader();
+      const arrayBuffer = await file.arrayBuffer();
+      const geometry = loader.parse(arrayBuffer);
+      geometry.computeVertexNormals();
+      const geo = BufferGeometryUtils.mergeVertices(geometry);
+      return new THREE.Mesh(geo, this.background.glass.material);
+    }
+
+    if (ext === 'stl') {
+      const { STLLoader } = await import('three/examples/jsm/loaders/STLLoader.js');
+      const loader = new STLLoader();
+      const arrayBuffer = await file.arrayBuffer();
+      const geometry = loader.parse(arrayBuffer);
+      geometry.computeVertexNormals();
+      const geo = BufferGeometryUtils.mergeVertices(geometry);
+      return new THREE.Mesh(geo, this.background.glass.material);
+    }
+
+    alert('Unsupported file type');
+    return null;
+  }
+
+  setRenderMode(mode) {
+    const renderMode = mode || 'surface';
+    if (this.particleRenderer) this.particleRenderer.object.visible = renderMode === 'surface';
+    if (this.pointRenderer) this.pointRenderer.object.visible = renderMode === 'points';
+    if (this.glyphRenderer) this.glyphRenderer.object.visible = renderMode === 'glyphs';
+  }
+
+  updateRenderers() {
+    if (this.particleRenderer) this.particleRenderer.update();
+    if (this.pointRenderer) this.pointRenderer.update();
+    if (this.glyphRenderer) this.glyphRenderer.update();
+  }
+
+  async updateSimulation(delta, elapsed) {
+    if (this.simulator) {
+      await this.simulator.update(delta, elapsed);
+    }
+  }
+
+  setMouseRay(origin, direction, position) {
+    if (this.simulator) {
+      this.simulator.setMouseRay(origin, direction, position);
+    }
+  }
+
+  get simulatorUniforms() {
+    return this.simulator?.uniforms;
+  }
+
+  dispose() {
+    if (this._glassSync) window.clearInterval(this._glassSync);
+    if (this._shapeSync) window.clearInterval(this._shapeSync);
+    this._glassSync = null;
+    this._shapeSync = null;
+  }
+}

--- a/aurora-refined/src/ui/LoadingOverlay.js
+++ b/aurora-refined/src/ui/LoadingOverlay.js
@@ -1,0 +1,51 @@
+/**
+ * LoadingOverlay encapsulates the bootstrapping veil used while the engine loads.
+ * It provides a progress API and exposes a small error surface that mirrors
+ * the behaviour of the legacy entrypoint without leaking DOM queries elsewhere.
+ */
+export default class LoadingOverlay {
+  constructor(root = document) {
+    this.root = root;
+    this.veil = root.getElementById('loading-veil');
+    this.progressTrack = root.getElementById('progress-track');
+    this.progressValue = root.getElementById('progress-value');
+    this.errorMessage = root.getElementById('error-message');
+
+    if (!this.veil || !this.progressValue || !this.errorMessage) {
+      throw new Error('LoadingOverlay: required DOM nodes are missing');
+    }
+  }
+
+  /**
+   * Update the progress bar to the given fraction. Optionally delays resolution
+   * which helps mimic the timing of the legacy progress animation.
+   */
+  updateProgress(fraction, delayMs = 0) {
+    const clamped = Math.max(0, Math.min(1, fraction ?? 0));
+    this.progressValue.style.width = `${(this.progressTrack.offsetWidth || 240) * clamped}px`;
+
+    return new Promise((resolve) => {
+      if (!delayMs) {
+        resolve();
+        return;
+      }
+      window.setTimeout(resolve, delayMs);
+    });
+  }
+
+  fadeOut() {
+    this.veil.style.opacity = '0';
+    window.setTimeout(() => {
+      this.veil.style.display = 'none';
+      this.veil.style.pointerEvents = 'none';
+    }, 850);
+  }
+
+  showError(message) {
+    this.progressValue.style.width = '0px';
+    this.veil.style.opacity = '1';
+    this.veil.style.pointerEvents = 'auto';
+    this.errorMessage.textContent = message;
+    this.errorMessage.style.visibility = 'visible';
+  }
+}

--- a/aurora-refined/src/utils/math.js
+++ b/aurora-refined/src/utils/math.js
@@ -1,0 +1,3 @@
+export const clamp01 = (value) => Math.max(0, Math.min(1, value ?? 0));
+
+export const clamp = (value, min, max) => Math.max(min, Math.min(max, value ?? min));

--- a/aurora-refined/vite.config.js
+++ b/aurora-refined/vite.config.js
@@ -1,0 +1,39 @@
+import { defineConfig } from 'vite';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import tslOperatorPlugin from 'vite-plugin-tsl-operator';
+import plainText from 'vite-plugin-plain-text';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root: dirname,
+  base: './',
+  assetsInclude: ['**/*.hdr'],
+  build: {
+    outDir: path.join(dirname, 'dist'),
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            if (id.includes('three')) return 'vendor-three';
+            if (id.includes('tweakpane')) return 'vendor-tweakpane';
+            return 'vendor';
+          }
+        },
+      },
+    },
+    chunkSizeWarningLimit: 1600,
+  },
+  server: {
+    port: 4321,
+  },
+  plugins: [
+    tslOperatorPlugin({ logs: false }),
+    plainText([
+      /\.obj$/,
+    ], {
+      namedExport: false,
+    }),
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite --host",
     "build": "vite build --mode=production",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "dev:refined": "vite --config aurora-refined/vite.config.js --host",
+    "build:refined": "vite build --config aurora-refined/vite.config.js --mode=production",
+    "preview:refined": "vite preview --config aurora-refined/vite.config.js"
   },
   "devDependencies": {
     "@babel/generator": "^7.26.9",


### PR DESCRIPTION
## Summary
- document the refactor vision and modular structure in `ARCHITECTURE_REDESIGN_PROPOSAL.md`
- build the new `aurora-refined` application with dedicated modules for environment, simulation, audio, effects, interaction, and performance plus a shared loading overlay
- add a dedicated Vite config and npm scripts to run and build the refined project

## Testing
- npm run build:refined

------
https://chatgpt.com/codex/tasks/task_e_68d361b2de6483279fd1c6d8629a1c20