### PR TITLE
Refactor post-processing pipeline into standalone module

### DIFF
--- a/POSTFX_PIPELINE_PLAN.md
+++ b/POSTFX_PIPELINE_PLAN.md
@@ -1,0 +1,35 @@
+# PostFX Pipeline Refactor Plan
+
+## Current Issues
+
+- Post-processing parameters are scattered across `config.js`, renderers, and the post FX module, making the pipeline difficult to reason about or extend.
+- Scene renderers conditionally write bloom mask data, coupling mesh materials with post effects and introducing redundant branching on every update.
+- Camera, depth of field, and environment exposure controls live in the general dashboard, producing an overcrowded UI and unclear ownership of parameters.
+- Lens automation writes back into the global config, further tangling responsibilities between rendering, camera control, and post-processing.
+
+## Goals
+
+1. Establish a standalone **PostFX pipeline** that owns every post effect parameter (bloom, DOF, chromatic aberration, grain, motion blur, grading, AA, SSR, GTAO, etc.) and camera exposure controls.
+2. Remove bloom-related state from renderers and replace mask dependencies with a unified pipeline-controlled bloom pass.
+3. Provide a left-aligned **PostFX panel** dedicated to camera/lens/post-processing controls for intuitive parameter discovery.
+4. Offer a cohesive state container for PostFX with subscription support so render systems (stage, lens pipeline, renderer) can react without coupling to the app config.
+5. Optimise updates by diffing state revisions and applying uniforms only when parameters change.
+
+## Planned Architecture
+
+- `src/postfx/state.js` exports a `PostFXState` singleton encapsulating all pipeline parameters, change notifications, and helpers.
+- `PostFX` consumes this state, lazily applying updated uniforms and rebuilding optional nodes when state revisions change.
+- `LensPipeline` reads/writes camera & DOF parameters through the shared state (including autofocus updates).
+- Stage renders read camera/exposure/environment data from the PostFX state while retaining simulation/world settings in the main config.
+- Renderers are simplified to always render their MRT outputs without bloom branching; the bloom mask is handled fully in post.
+- A new `PostFXPanel` UI module (left-side layout) manipulates PostFX state exclusively and stays in sync via subscriptions.
+
+## Implementation Steps
+
+1. Introduce the `PostFXState` module with defaults, setters, and subscription API.
+2. Refactor `PostFX` to consume the new state, remove config dependencies, and drop renderer-provided bloom masks.
+3. Update `LensPipeline`, `Stage`, and `main` to reference the PostFX state for camera/lens/FX data.
+4. Strip PostFX-related fields from `config.js` and simplify renderers to remove bloom toggles.
+5. Replace dashboard bloom/DOF controls with the new `PostFXPanel` left-side UI.
+6. Verify wiring end-to-end: state updates trigger post-processing, camera exposure, and UI refresh without touching the main config.
+

--- a/src/audio/audioRouter.js
+++ b/src/audio/audioRouter.js
@@ -1,5 +1,7 @@
 // AudioRouter: map audio features to simulation and visual configuration safely
 
+import { postFxState } from "../postfx/state.js";
+
 function clamp(x, lo, hi) { return Math.max(lo, Math.min(hi, x)); }
 
 export class AudioRouter {
@@ -123,8 +125,8 @@ export class AudioRouter {
     if (this.routes.envSway.enable && envBase) {
       const r = this.routes.envSway;
       const sway = (get(r.source) * r.gain) * Math.sin(elapsed * 1.6) + (f.beat * 0.06);
-      conf.bgRotY = envBase.bg + sway;
-      conf.envRotY = envBase.env - sway * 0.8;
+      postFxState.set(['camera', 'bgRotation'], envBase.bg + sway);
+      postFxState.set(['camera', 'envRotation'], envBase.env - sway * 0.8);
     }
 
     // Color mode: audio saturation boost

--- a/src/config.js
+++ b/src/config.js
@@ -8,19 +8,6 @@ class Conf {
     maxParticles = 8192 * 16;
     particles = 8192 * 4;
 
-    bloom = true;
-    bloomStrength = 1.2;
-    bloomRadius = 1.0;
-    bloomThreshold = 0.0005;
-
-    // Depth of Field (approx)
-    dofEnabled = true;
-    dofAutoFocus = true; // focus distance follows pointer
-    dofFocus = 0.8;      // macro default
-    dofRange = 0.08;     // shallow macro range
-    dofAmount = 1.15;    // larger bokeh
-    dofHighQuality = true; // HQ by default
-
     // World/domain scaling (visual mapping of 64^3 grid to world units)
     worldScale = 2.0; // scale up domain to fill more of the page by default
     autoWorldFit = true; // dynamically fit domain to viewport
@@ -35,12 +22,6 @@ class Conf {
     perfStep = 4096;   // particle step
 
     // Stage/Camera/Environment controls
-    fov = 60;
-    exposure = 0.66;
-    envIntensity = 0.5;
-    bgRotY = 2.15;
-    envRotY = -2.15;
-
     // Glass boundary controls
     boundariesEnabled = false;
     glassIor = 1.5;
@@ -128,47 +109,6 @@ class Conf {
     _audioLevel = 0.0; _audioBeat = 0.0; _audioBass = 0.0; _audioMid = 0.0; _audioTreble = 0.0;
     _audioTempoPhase = 0.0; _audioTempoBpm = 0.0;
 
-    // Post FX extras
-    postFxEnabled = true;
-    vignetteEnabled = false;
-    vignetteAmount = 0.25;
-    grainEnabled = false;
-    grainAmount = 0.08;
-    chromaEnabled = false;
-    chromaAmount = 0.0025;
-    // Motion blur (temporal screen direction approx)
-    motionBlurEnabled = false;
-    motionBlurAmount = 0.35;
-    // Color grade controls
-    postSaturation = 1.0;
-    postContrast = 1.0;
-    postLift = 0.0;
-    // Anti-aliasing
-    aaMode = 'off'; // 'off' | 'fxaa' | 'smaa' | 'traa'
-    aaAmount = 1.0;
-    // GTAO
-    gtaoEnabled = false;
-    gtaoRadius = 0.25;
-    gtaoThickness = 1.0;
-    gtaoDistanceExponent = 1.0;
-    gtaoScale = 1.0;
-    gtaoSamples = 16;
-    gtaoResolutionScale = 1.0;
-    // SSGI
-    ssgiEnabled = false;
-    ssgiSlices = 2;
-    ssgiSteps = 8;
-    ssgiIntensity = 0.6;
-    ssgiResolutionScale = 1.0;
-    ssgiDenoise = true;
-    // SSR
-    ssrEnabled = false;
-    ssrOpacity = 0.2;
-    ssrMaxDistance = 1.0;
-    ssrThickness = 0.1;
-    ssrResolutionScale = 0.75;
-    ssrMetalness = 0.8;
-
     constructor(info) {
         if (mobile()) {
             this.maxParticles = 8192 * 8;
@@ -229,17 +169,15 @@ class Conf {
     _exportPreset() {
         // Whitelist of presettable fields
         const keys = [
-            'particles','size','points','bloom','bloomStrength','bloomRadius','bloomThreshold',
-            'worldScale','autoWorldFit','fitMode','fitMargin','zScale','borderMode','dofEnabled','dofHighQuality','dofFocus','dofRange','dofAmount','dofNearBoost','dofFarBoost','dofHighlightThreshold','dofHighlightGain','colorMode',
-            'fov','envIntensity','exposure','bgRotY','envRotY',
+            'particles','size','points','renderMode','colorMode',
+            'worldScale','autoWorldFit','fitMode','fitMargin','zScale','borderMode',
             'boundariesEnabled','boundaryShape','glassIor','glassThickness','glassRoughness','glassDispersion','glassAttenuationDistance','glassAttenuationColor','collisionShrink','collisionRestitution','collisionFriction',
             'run','noise','speed','substeps','apicBlend','physMaxVelocity','cflSafety','vorticityEnabled','vorticityEps','xsphEnabled','xsphEps','sdfSphere','sdfCenterZ','sdfRadius','gravity','density','stiffness','dynamicViscosity',
             'jetEnabled','jetStrength','jetRadius','jetPos','jetDir','vortexEnabled','vortexStrength','vortexRadius','vortexCenter',
             'curlEnabled','curlStrength','curlScale','curlTime',
             'orbitEnabled','orbitStrength','orbitRadius','orbitAxis',
             'waveEnabled','waveAmplitude','waveScale','waveSpeed','waveAxis',
-            'audioEnabled','audioSource','audioSensitivity','audioAttack','audioRelease','audioBassGain','audioMidGain','audioTrebleGain','audioBeatBoost',
-            'vignetteEnabled','vignetteAmount','grainEnabled','grainAmount','chromaEnabled','chromaAmount','motionBlurEnabled','motionBlurAmount','postSaturation','postContrast','postLift','aaMode','aaAmount','gtaoEnabled','gtaoRadius','gtaoThickness','gtaoDistanceExponent','gtaoScale','gtaoSamples','gtaoResolutionScale','ssgiEnabled','ssgiSlices','ssgiSteps','ssgiIntensity','ssgiResolutionScale','ssgiDenoise','ssrEnabled','ssrOpacity','ssrMaxDistance','ssrThickness','ssrResolutionScale','ssrMetalness','lensEnabled','sensorWidth','focalLength','fStop','lensDriveFov','focusSmooth','dofQuality','apertureBlades','apertureRotation','aperturePetal','anamorphic'
+            'audioEnabled','audioSource','audioSensitivity','audioAttack','audioRelease','audioBassGain','audioMidGain','audioTrebleGain','audioBeatBoost'
         ];
         const out = {};
         keys.forEach(k => { out[k] = this[k]; });
@@ -293,42 +231,31 @@ class Conf {
                 worldScale: 2.0,
                 boundariesEnabled: false,
                 renderMode: 'surface',
-                bloom: true, bloomStrength: 1.2, bloomRadius: 1.0, bloomThreshold: 0.0005,
-                dofEnabled: true, dofFocus: 1.1, dofRange: 0.25, dofAmount: 0.85,
-                fov: 60, exposure: 0.66, envIntensity: 0.9,
                 gravity: 2, speed: 1.6, density: 1.4, substeps: 2, apicBlend: 0.2,
                 particles: 8192 * 4,
             },
             'Glass Dodeca': {
                 boundariesEnabled: true, boundaryShape: 'dodeca',
                 glassIor: 1.52, glassThickness: 0.38, glassRoughness: 0.04, glassDispersion: 0.28,
-                bloom: true, bloomStrength: 0.9, bloomRadius: 0.9, bloomThreshold: 0.001,
-                dofEnabled: true, dofFocus: 1.2, dofRange: 0.35, dofAmount: 0.7,
                 worldScale: 1.3, renderMode: 'surface', gravity: 1, speed: 1.2, density: 1.0,
             },
             'Glyph Motion': {
                 renderMode: 'glyphs', worldScale: 1.8,
-                bloom: true, bloomStrength: 0.8, bloomRadius: 0.8, bloomThreshold: 0.002,
-                dofEnabled: true, dofFocus: 1.0, dofRange: 0.2, dofAmount: 0.8,
                 boundariesEnabled: false, gravity: 0, speed: 1.4, density: 1.1, apicBlend: 0.35,
             },
             'Points Storm': {
                 renderMode: 'points', particles: 8192 * 8, size: 0.9,
-                bloom: false, dofEnabled: false,
                 worldScale: 2.2, boundariesEnabled: false, gravity: 3, speed: 1.5, density: 0.9,
             },
             'Sphere Tank': {
                 boundariesEnabled: true, boundaryShape: 'sphere', sdfSphere: true, sdfRadius: 18, sdfCenterZ: 20,
                 worldScale: 1.2, renderMode: 'surface',
-                bloom: true, bloomStrength: 0.7, bloomRadius: 0.6, bloomThreshold: 0.002,
-                dofEnabled: false, gravity: 1, speed: 1.0, density: 1.2,
+                gravity: 1, speed: 1.0, density: 1.2,
             },
             'Vortex Jet': {
                 boundariesEnabled: false, worldScale: 1.8,
                 jetEnabled: true, jetStrength: 1.0, jetRadius: 10.0, jetPos: { x: 20, y: 54, z: 28 }, jetDir: { x: 0, y: -1, z: 0 },
                 vortexEnabled: true, vortexStrength: 0.8, vortexRadius: 22.0, vortexCenter: { x: 32, y: 32 },
-                bloom: true, bloomStrength: 1.1, bloomRadius: 0.9, bloomThreshold: 0.001,
-                dofEnabled: true, dofFocus: 1.05, dofRange: 0.3, dofAmount: 0.75,
                 gravity: 0, speed: 1.8, density: 1.1,
             },
             'Bass Jet': {
@@ -338,8 +265,6 @@ class Conf {
                 jetEnabled: true, jetStrength: 0.9, jetRadius: 12.0, jetPos: { x: 32, y: 58, z: 28 }, jetDir: { x: 0, y: -1, z: 0 },
                 vortexEnabled: false,
                 apicBlend: 0.25, physMaxVelocity: 2.6, cflSafety: 0.5,
-                bloom: true, bloomStrength: 1.0, bloomRadius: 0.9, bloomThreshold: 0.0015,
-                dofEnabled: true, dofFocus: 1.0, dofRange: 0.22, dofAmount: 0.85,
                 gravity: 0, speed: 1.7, density: 1.2,
             },
             'Dance Surface': {
@@ -348,8 +273,6 @@ class Conf {
                 boundariesEnabled: false, renderMode: 'surface', worldScale: 2.0,
                 jetEnabled: false, vortexEnabled: true, vortexStrength: 0.9, vortexRadius: 20.0, vortexCenter: { x: 32, y: 32 },
                 apicBlend: 0.35, physMaxVelocity: 2.8, cflSafety: 0.5,
-                bloom: true, bloomStrength: 0.9, bloomRadius: 0.9, bloomThreshold: 0.002,
-                dofEnabled: true, dofFocus: 1.0, dofRange: 0.25, dofAmount: 0.8,
                 gravity: 0, speed: 1.8, density: 1.1,
             },
             'Audio Showcase': {
@@ -363,8 +286,6 @@ class Conf {
                 vortexEnabled: true, vortexStrength: 0.7, vortexRadius: 20.0, vortexCenter: { x: 32, y: 32 },
                 // Visuals
                 renderMode: 'surface', worldScale: 2.0,
-                bloom: true, bloomStrength: 1.0, bloomRadius: 0.9, bloomThreshold: 0.0013,
-                dofEnabled: true, dofFocus: 1.05, dofRange: 0.24, dofAmount: 0.85,
                 gravity: 0, speed: 1.7, density: 1.2,
             },
             'Nebula Curl': {
@@ -374,8 +295,6 @@ class Conf {
                 waveEnabled: false,
                 renderMode: 'surface', worldScale: 1.9,
                 vorticityEnabled: true, vorticityEps: 0.18, xsphEnabled: true, xsphEps: 0.06,
-                bloom: true, bloomStrength: 1.0, bloomRadius: 0.9, bloomThreshold: 0.0015,
-                dofEnabled: true, dofFocus: 1.1, dofRange: 0.22, dofAmount: 0.85,
                 gravity: 0, speed: 1.6, density: 1.2,
             },
             'Orbit Dance': {
@@ -384,8 +303,6 @@ class Conf {
                 curlEnabled: true, curlStrength: 0.6, curlScale: 0.02, curlTime: 0.7,
                 waveEnabled: false,
                 renderMode: 'glyphs', worldScale: 1.8,
-                bloom: true, bloomStrength: 0.9, bloomRadius: 0.9, bloomThreshold: 0.001,
-                dofEnabled: true, dofFocus: 1.0, dofRange: 0.25, dofAmount: 0.8,
                 gravity: 0, speed: 1.7, density: 1.1,
             },
             'Beat Waves': {
@@ -394,8 +311,6 @@ class Conf {
                 orbitEnabled: true, orbitAxis: 'y', orbitRadius: 18.0, orbitStrength: 0.6,
                 curlEnabled: false,
                 renderMode: 'surface', worldScale: 2.0,
-                bloom: true, bloomStrength: 0.95, bloomRadius: 0.9, bloomThreshold: 0.001,
-                dofEnabled: true, dofFocus: 1.0, dofRange: 0.22, dofAmount: 0.8,
                 gravity: 0, speed: 1.6, density: 1.2,
             },
             'Bass Storm': {
@@ -405,8 +320,6 @@ class Conf {
                 curlEnabled: true, curlStrength: 0.7, curlScale: 0.024, curlTime: 0.8,
                 waveEnabled: false,
                 renderMode: 'surface', worldScale: 1.9,
-                bloom: true, bloomStrength: 1.1, bloomRadius: 0.95, bloomThreshold: 0.001,
-                dofEnabled: true, dofFocus: 1.05, dofRange: 0.2, dofAmount: 0.85,
                 gravity: 0, speed: 1.8, density: 1.25,
             },
             'Perc Glitch': {
@@ -415,8 +328,6 @@ class Conf {
                 curlEnabled: true, curlStrength: 0.5, curlScale: 0.03, curlTime: 1.2,
                 orbitEnabled: false,
                 renderMode: 'glyphs', worldScale: 1.7,
-                bloom: true, bloomStrength: 0.9, bloomRadius: 0.85, bloomThreshold: 0.0015,
-                dofEnabled: false,
                 gravity: 0, speed: 1.9, density: 1.1,
             },
             'Ambient Wash': {
@@ -425,8 +336,6 @@ class Conf {
                 orbitEnabled: true, orbitAxis: 'y', orbitRadius: 28.0, orbitStrength: 0.5,
                 waveEnabled: true, waveAxis: 'z', waveAmplitude: 0.25, waveScale: 0.09, waveSpeed: 0.9,
                 renderMode: 'surface', worldScale: 2.0,
-                bloom: true, bloomStrength: 0.8, bloomRadius: 0.8, bloomThreshold: 0.002,
-                dofEnabled: true, dofFocus: 1.2, dofRange: 0.3, dofAmount: 0.7,
                 gravity: 0, speed: 1.4, density: 1.1,
             },
             'Chillwave Drift': {
@@ -435,8 +344,6 @@ class Conf {
                 curlEnabled: true, curlStrength: 0.6, curlScale: 0.024, curlTime: 0.7,
                 waveEnabled: true, waveAxis: 'y', waveAmplitude: 0.35, waveScale: 0.12, waveSpeed: 1.0,
                 renderMode: 'surface', worldScale: 2.1,
-                bloom: true, bloomStrength: 0.9, bloomRadius: 0.9, bloomThreshold: 0.001,
-                dofEnabled: true, dofFocus: 1.1, dofRange: 0.28, dofAmount: 0.75,
                 gravity: 0, speed: 1.6, density: 1.15,
             },
             'Trance Swirl': {
@@ -446,8 +353,6 @@ class Conf {
                 curlEnabled: false,
                 waveEnabled: true, waveAxis: 'y', waveAmplitude: 0.4, waveScale: 0.12, waveSpeed: 1.4,
                 renderMode: 'surface', worldScale: 2.0,
-                bloom: true, bloomStrength: 1.0, bloomRadius: 0.95, bloomThreshold: 0.0012,
-                dofEnabled: true, dofFocus: 1.0, dofRange: 0.22, dofAmount: 0.8,
                 gravity: 0, speed: 1.8, density: 1.2,
             },
         };

--- a/src/io/dashboard.js
+++ b/src/io/dashboard.js
@@ -90,90 +90,11 @@ export const buildDashboard = (conf) => {
     }).on('change', (ev) => { conf.borderMode = ev.value; });
 
     // DOF controls moved under Post FX
-    const dofMacro = () => {
-        conf.zScale = 0.18;
-        conf.dofEnabled = true;
-        conf.dofHighQuality = true;
-        conf.dofAutoFocus = true;
-        conf.dofRange = 0.06;
-        conf.dofAmount = 1.30;
-        conf.fov = Math.max(60, conf.fov);
-        conf.updateParams();
-        if (conf.gui) conf.gui.refresh();
-    };
-
     const perf = settings.addFolder({ title: 'performance', expanded: false });
     perf.addBinding(conf, 'autoPerf', { label: 'auto adjust' });
     perf.addBinding(conf, 'perfMinFps', { min: 20, max: 80, step: 1, label: 'min fps' });
     perf.addBinding(conf, 'perfMaxFps', { min: 30, max: 120, step: 1, label: 'max fps' });
     perf.addBinding(conf, 'perfStep', { min: 1024, max: 16384, step: 1024, label: 'step' });
-
-    const camera = settings.addFolder({
-        title: "camera",
-        expanded: false,
-    });
-    camera.addBinding(conf, "fov", { min: 30, max: 100, step: 1 });
-    // Lens controls (approximate mapping to DOF params)
-    const lens = settings.addFolder({ title: 'lens & dof', expanded: false });
-    conf.lensEnabled = false;
-    conf.sensorWidth = 36.0; // mm (full-frame)
-    conf.focalLength = 24.0; // mm
-    conf.fStop = 1.8;
-    conf.lensDriveFov = true;
-    conf.focusSmooth = 0.2;
-    lens.addBinding(conf, 'lensEnabled', { label: 'enable' });
-    lens.addBinding(conf, 'sensorWidth', { min: 12.0, max: 70.0, step: 0.1, label: 'sensor (mm)' });
-    lens.addBinding(conf, 'focalLength', { min: 8.0, max: 120.0, step: 0.1, label: 'focal (mm)' });
-    lens.addBinding(conf, 'fStop', { min: 0.7, max: 16.0, step: 0.1, label: 'f‑stop' });
-    lens.addBinding(conf, 'lensDriveFov', { label: 'drive FOV' });
-    lens.addBinding(conf, 'focusSmooth', { min: 0.0, max: 0.9, step: 0.01, label: 'focus smooth' });
-    // DOF controls (moved here)
-    lens.addBinding(conf, 'dofEnabled', { label: 'dof enable' });
-    lens.addBinding(conf, 'dofAutoFocus', { label: 'auto focus (pointer)' });
-    lens.addBinding(conf, 'dofHighQuality', { label: 'high quality' });
-    lens.addBinding(conf, 'dofFocus', { min: 0.1, max: 3.0, step: 0.01 });
-    lens.addBinding(conf, 'dofRange', { min: 0.02, max: 2.0, step: 0.01 });
-    lens.addBinding(conf, 'dofAmount', { min: 0.0, max: 2.0, step: 0.01 });
-    // DOF quality (0.25..1.0)
-    conf.dofQuality = 1.0;
-    lens.addBinding(conf, 'dofQuality', { min: 0.25, max: 1.0, step: 0.01, label: 'dof quality' });
-    lens.addBlade({ view: 'button', label: 'macro', title: 'Macro Shot' }).on('click', dofMacro);
-    // Advanced bokeh controls
-    conf.dofNearBoost = conf.dofNearBoost ?? 1.0;
-    conf.dofFarBoost = conf.dofFarBoost ?? 1.0;
-    conf.dofHighlightThreshold = conf.dofHighlightThreshold ?? 0.8;
-    conf.dofHighlightGain = conf.dofHighlightGain ?? 0.6;
-    lens.addBinding(conf, 'dofNearBoost', { min: 0.5, max: 3.0, step: 0.01, label: 'near boost' });
-    lens.addBinding(conf, 'dofFarBoost', { min: 0.5, max: 3.0, step: 0.01, label: 'far boost' });
-    lens.addBinding(conf, 'dofHighlightThreshold', { min: 0.0, max: 1.0, step: 0.01, label: 'hi thresh' });
-    lens.addBinding(conf, 'dofHighlightGain', { min: 0.0, max: 2.0, step: 0.01, label: 'hi gain' });
-    // Aperture & anamorphic
-    conf.apertureBlades = 7; // polygon blades
-    conf.apertureRotation = 0.0; // radians
-    conf.aperturePetal = 1.0; // sharpness of polygon weighting
-    conf.anamorphic = 0.0; // -1..1 (negative vertical, positive horizontal)
-    lens.addBinding(conf, 'apertureBlades', { min: 3, max: 12, step: 1, label: 'blades' });
-    lens.addBinding(conf, 'apertureRotation', { min: -3.1416, max: 3.1416, step: 0.01, label: 'apert rot' });
-    lens.addBinding(conf, 'aperturePetal', { min: 0.2, max: 2.5, step: 0.01, label: 'apert petal' });
-    lens.addBinding(conf, 'anamorphic', { min: -1.0, max: 1.0, step: 0.01, label: 'anamorphic' });
-    // Creative presets
-    lens.addBlade({ view: 'button', label: 'preset', title: 'Creamy Wide' }).on('click', () => {
-        conf.lensEnabled = true; conf.lensDriveFov = true;
-        conf.sensorWidth = 36.0; conf.focalLength = 24.0; conf.fStop = 1.4;
-        conf.dofEnabled = true; conf.dofAutoFocus = true; conf.dofHighQuality = true;
-        conf.dofRange = 0.06; conf.dofAmount = 1.4; conf.dofFarBoost = 2.2; conf.dofNearBoost = 1.2;
-        conf.dofHighlightThreshold = 0.8; conf.dofHighlightGain = 1.1; conf.focusSmooth = 0.25;
-        if (conf.gui) conf.gui.refresh();
-    });
-
-    const environment = settings.addFolder({
-        title: "environment",
-        expanded: false,
-    });
-    environment.addBinding(conf, "envIntensity", { min: 0.0, max: 5.0, step: 0.05 });
-    environment.addBinding(conf, "exposure", { min: 0.0, max: 2.0, step: 0.01 });
-    environment.addBinding(conf, "bgRotY", { label: 'bg rot Y', min: -Math.PI, max: Math.PI, step: 0.01 });
-    environment.addBinding(conf, "envRotY", { label: 'env rot Y', min: -Math.PI, max: Math.PI, step: 0.01 });
 
     const boundary = settings.addFolder({
         title: "boundary",
@@ -293,86 +214,6 @@ export const buildDashboard = (conf) => {
     }).on('change', (ev) => { conf.waveAxis = ev.value; });
 
     // Audio controls moved to dedicated AudioPanel (src/ui/audioPanel.js)
-
-    // Post FX unified panel
-    const fx = settings.addFolder({ title: 'post fx', expanded: false });
-    // Master toggle
-    fx.addBinding(conf, 'postFxEnabled', { label: 'enable all' });
-    // Bloom
-    const fxBloom = fx.addFolder({ title: 'bloom', expanded: false });
-    fxBloom.addBinding(conf, "bloom", { label: 'enable' });
-    fxBloom.addBinding(conf, "bloomStrength", { min: 0, max: 2, step: 0.01 });
-    fxBloom.addBinding(conf, "bloomRadius", { min: 0, max: 1.2, step: 0.01 });
-    fxBloom.addBinding(conf, "bloomThreshold", { min: 0, max: 1, step: 0.001 });
-    // Depth of field
-    // DOF controls moved into Lens panel for cohesion
-    // Vignette
-    const fxVig = fx.addFolder({ title: 'vignette', expanded: false });
-    fxVig.addBinding(conf, 'vignetteEnabled', { label: 'enable' });
-    fxVig.addBinding(conf, 'vignetteAmount', { min: 0.0, max: 1.0, step: 0.01, label: 'amount' });
-    // Grain
-    const fxGrain = fx.addFolder({ title: 'grain', expanded: false });
-    fxGrain.addBinding(conf, 'grainEnabled', { label: 'enable' });
-    fxGrain.addBinding(conf, 'grainAmount', { min: 0.0, max: 0.5, step: 0.01, label: 'amount' });
-    // Chromatic aberration
-    const fxCA = fx.addFolder({ title: 'chroma ab', expanded: false });
-    fxCA.addBinding(conf, 'chromaEnabled', { label: 'enable' });
-    fxCA.addBinding(conf, 'chromaAmount', { min: 0.0, max: 0.01, step: 0.0001, label: 'amount' });
-    conf.chromaCenter = conf.chromaCenter || { x: 0.5, y: 0.5 };
-    conf.chromaScale = conf.chromaScale || 1.0;
-    fxCA.addBinding(conf, 'chromaCenter', { x: { min: 0.0, max: 1.0, step: 0.001 }, y: { min: 0.0, max: 1.0, step: 0.001 } });
-    fxCA.addBinding(conf, 'chromaScale', { min: 0.2, max: 3.0, step: 0.01, label: 'scale' });
-    // Motion blur
-    const fxMB = fx.addFolder({ title: 'motion blur', expanded: false });
-    fxMB.addBinding(conf, 'motionBlurEnabled', { label: 'enable' });
-    fxMB.addBinding(conf, 'motionBlurAmount', { min: 0.0, max: 1.0, step: 0.01, label: 'amount' });
-    // Grading
-    const fxGrade = fx.addFolder({ title: 'grading', expanded: false });
-    fxGrade.addBinding(conf, 'postSaturation', { min: 0.0, max: 2.0, step: 0.01, label: 'saturation' });
-    fxGrade.addBinding(conf, 'postContrast', { min: 0.5, max: 2.0, step: 0.01, label: 'contrast' });
-    fxGrade.addBinding(conf, 'postLift', { min: -0.3, max: 0.3, step: 0.005, label: 'lift' });
-    // Anti-aliasing
-    const fxAA = fx.addFolder({ title: 'anti aliasing', expanded: false });
-    fxAA.addBlade({
-        view: 'list',
-        label: 'mode',
-        options: [
-            { text: 'off', value: 'off' },
-            { text: 'fxaa', value: 'fxaa' },
-            { text: 'smaa', value: 'smaa' },
-            { text: 'traa', value: 'traa' },
-        ],
-        value: conf.aaMode,
-    }).on('change', (ev) => { conf.aaMode = ev.value; });
-    fxAA.addBinding(conf, 'aaAmount', { min: 0.2, max: 2.0, step: 0.05, label: 'amount' });
-    // Ambient Occlusion (GTAO)
-    const fxAO = fx.addFolder({ title: 'ambient occlusion', expanded: false });
-    fxAO.addBinding(conf, 'gtaoEnabled', { label: 'enable' });
-    fxAO.addBinding(conf, 'gtaoRadius', { min: 0.05, max: 2.0, step: 0.01, label: 'radius' });
-    fxAO.addBinding(conf, 'gtaoThickness', { min: 0.1, max: 4.0, step: 0.1, label: 'thickness' });
-    fxAO.addBinding(conf, 'gtaoDistanceExponent', { min: 0.5, max: 3.0, step: 0.05, label: 'distance exp' });
-    fxAO.addBinding(conf, 'gtaoScale', { min: 0.1, max: 2.0, step: 0.05, label: 'scale' });
-    fxAO.addBinding(conf, 'gtaoSamples', { min: 4, max: 32, step: 1, label: 'samples' });
-    fxAO.addBinding(conf, 'gtaoResolutionScale', { min: 0.25, max: 1.0, step: 0.05, label: 'res scale' });
-    // Global Illumination (SSGI)
-    const fxGI = fx.addFolder({ title: 'global illumination', expanded: false });
-    fxGI.addBinding(conf, 'ssgiEnabled', { label: 'enable' });
-    fxGI.addBinding(conf, 'ssgiSlices', { min: 1, max: 4, step: 1, label: 'slices' });
-    fxGI.addBinding(conf, 'ssgiSteps', { min: 1, max: 32, step: 1, label: 'steps' });
-    fxGI.addBinding(conf, 'ssgiIntensity', { min: 0.0, max: 2.0, step: 0.01, label: 'intensity' });
-    fxGI.addBinding(conf, 'ssgiResolutionScale', { min: 0.25, max: 1.0, step: 0.05, label: 'res scale' });
-    fxGI.addBinding(conf, 'ssgiDenoise', { label: 'denoise' });
-    // Reflections (SSR)
-    const fxSSR = fx.addFolder({ title: 'reflections', expanded: false });
-    fxSSR.addBinding(conf, 'ssrEnabled', { label: 'enable' });
-    fxSSR.addBinding(conf, 'ssrOpacity', { min: 0.0, max: 1.0, step: 0.01, label: 'opacity' });
-    fxSSR.addBinding(conf, 'ssrMaxDistance', { min: 0.1, max: 4.0, step: 0.05, label: 'max dist' });
-    fxSSR.addBinding(conf, 'ssrThickness', { min: 0.01, max: 1.0, step: 0.01, label: 'thickness' });
-    fxSSR.addBinding(conf, 'ssrResolutionScale', { min: 0.25, max: 1.0, step: 0.05, label: 'res scale' });
-    fxSSR.addBinding(conf, 'ssrMetalness', { min: 0.0, max: 1.0, step: 0.01, label: 'metalness' });
-
-    /*settings.addBinding(conf, "roughness", { min: 0.0, max: 1, step: 0.01 });
-    settings.addBinding(conf, "metalness", { min: 0.0, max: 1, step: 0.01 });*/
 
     // Presets
     const presets = gui.addFolder({

--- a/src/io/postfxPanel.js
+++ b/src/io/postfxPanel.js
@@ -1,0 +1,215 @@
+import { Pane } from "tweakpane";
+import * as EssentialsPlugin from "@tweakpane/plugin-essentials";
+import { postFxState, POST_FX_DEFAULTS, syncStateObject } from "../postfx/state.js";
+
+const clamp = (x, lo, hi) => Math.max(lo, Math.min(hi, x));
+
+class PostFXPanel {
+    constructor(lensPipeline = null) {
+        this.lens = lensPipeline;
+        this.gui = null;
+        this._container = null;
+        this._ui = postFxState.snapshot();
+        this._unsubscribe = null;
+    }
+
+    _bind(folder, target, prop, path, params = {}) {
+        const binding = folder.addBinding(target, prop, params);
+        binding.on('change', (ev) => {
+            postFxState.set(path, ev.value);
+        });
+        return binding;
+    }
+
+    _initCameraControls(root) {
+        const cameraFolder = root.addFolder({ title: 'camera & env', expanded: false });
+        this._bind(cameraFolder, this._ui.camera, 'fov', ['camera', 'fov'], { min: 20, max: 120, step: 1 });
+        this._bind(cameraFolder, this._ui.camera, 'exposure', ['camera', 'exposure'], { min: 0.1, max: 2.5, step: 0.01 });
+        this._bind(cameraFolder, this._ui.camera, 'envIntensity', ['camera', 'envIntensity'], { min: 0.0, max: 3.0, step: 0.01, label: 'env intensity' });
+        this._bind(cameraFolder, this._ui.camera, 'bgRotation', ['camera', 'bgRotation'], { min: -Math.PI, max: Math.PI, step: 0.01, label: 'bg rot' });
+        this._bind(cameraFolder, this._ui.camera, 'envRotation', ['camera', 'envRotation'], { min: -Math.PI, max: Math.PI, step: 0.01, label: 'env rot' });
+        cameraFolder.addBlade({ view: 'button', label: 'cam', title: 'reset camera' }).on('click', () => {
+            postFxState.update({ camera: { ...POST_FX_DEFAULTS.camera } });
+        });
+    }
+
+    _initLensControls(root) {
+        const lensFolder = root.addFolder({ title: 'lens', expanded: false });
+        this._bind(lensFolder, this._ui.lens, 'enabled', ['lens', 'enabled'], { label: 'enable' });
+        this._bind(lensFolder, this._ui.lens, 'sensorWidth', ['lens', 'sensorWidth'], { min: 12.0, max: 70.0, step: 0.1, label: 'sensor (mm)' });
+        this._bind(lensFolder, this._ui.lens, 'focalLength', ['lens', 'focalLength'], { min: 8.0, max: 120.0, step: 0.1, label: 'focal (mm)' });
+        this._bind(lensFolder, this._ui.lens, 'fStop', ['lens', 'fStop'], { min: 0.7, max: 16.0, step: 0.1, label: 'f-stop' });
+        this._bind(lensFolder, this._ui.lens, 'driveFov', ['lens', 'driveFov'], { label: 'drive FOV' });
+        this._bind(lensFolder, this._ui.lens, 'focusSmooth', ['lens', 'focusSmooth'], { min: 0.0, max: 0.9, step: 0.01, label: 'focus smooth' });
+        lensFolder.addBlade({ view: 'button', label: 'preset', title: 'macro portrait' }).on('click', () => {
+            postFxState.update({
+                lens: { enabled: true, driveFov: true, sensorWidth: 36.0, focalLength: 35.0, fStop: 1.4, focusSmooth: 0.25 },
+                dof: {
+                    enabled: true,
+                    autoFocus: true,
+                    range: 0.06,
+                    amount: 1.35,
+                    nearBoost: 1.3,
+                    farBoost: 2.1,
+                    highlightThreshold: 0.78,
+                    highlightGain: 1.05,
+                }
+            });
+        });
+    }
+
+    _initDofControls(root) {
+        const dofFolder = root.addFolder({ title: 'depth of field', expanded: true });
+        this._bind(dofFolder, this._ui.dof, 'enabled', ['dof', 'enabled'], { label: 'enable' });
+        this._bind(dofFolder, this._ui.dof, 'autoFocus', ['dof', 'autoFocus'], { label: 'auto focus' });
+        this._bind(dofFolder, this._ui.dof, 'focus', ['dof', 'focus'], { min: 0.1, max: 5.0, step: 0.01 });
+        this._bind(dofFolder, this._ui.dof, 'range', ['dof', 'range'], { min: 0.01, max: 2.5, step: 0.01, label: 'range' });
+        this._bind(dofFolder, this._ui.dof, 'amount', ['dof', 'amount'], { min: 0.0, max: 2.0, step: 0.01, label: 'amount' });
+        this._bind(dofFolder, this._ui.dof, 'quality', ['dof', 'quality'], { min: 0.25, max: 1.0, step: 0.01, label: 'quality' });
+        this._bind(dofFolder, this._ui.dof, 'nearBoost', ['dof', 'nearBoost'], { min: 0.2, max: 4.0, step: 0.01, label: 'near boost' });
+        this._bind(dofFolder, this._ui.dof, 'farBoost', ['dof', 'farBoost'], { min: 0.2, max: 4.0, step: 0.01, label: 'far boost' });
+        this._bind(dofFolder, this._ui.dof, 'highlightThreshold', ['dof', 'highlightThreshold'], { min: 0.0, max: 1.0, step: 0.01, label: 'hi threshold' });
+        this._bind(dofFolder, this._ui.dof, 'highlightGain', ['dof', 'highlightGain'], { min: 0.0, max: 2.5, step: 0.01, label: 'hi gain' });
+        this._bind(dofFolder, this._ui.dof, 'apertureBlades', ['dof', 'apertureBlades'], { min: 3, max: 12, step: 1, label: 'blades' });
+        this._bind(dofFolder, this._ui.dof, 'apertureRotation', ['dof', 'apertureRotation'], { min: -Math.PI, max: Math.PI, step: 0.01, label: 'apert rot' });
+        this._bind(dofFolder, this._ui.dof, 'aperturePetal', ['dof', 'aperturePetal'], { min: 0.2, max: 3.0, step: 0.01, label: 'petal' });
+        this._bind(dofFolder, this._ui.dof, 'anamorphic', ['dof', 'anamorphic'], { min: -1.0, max: 1.0, step: 0.01, label: 'anamorphic' });
+    }
+
+    _initBloomControls(root) {
+        const bloomFolder = root.addFolder({ title: 'bloom', expanded: false });
+        this._bind(bloomFolder, this._ui.bloom, 'enabled', ['bloom', 'enabled'], { label: 'enable' });
+        this._bind(bloomFolder, this._ui.bloom, 'strength', ['bloom', 'strength'], { min: 0.0, max: 3.0, step: 0.01 });
+        this._bind(bloomFolder, this._ui.bloom, 'radius', ['bloom', 'radius'], { min: 0.1, max: 2.0, step: 0.01 });
+        this._bind(bloomFolder, this._ui.bloom, 'threshold', ['bloom', 'threshold'], { min: 0.0, max: 1.0, step: 0.001 });
+    }
+
+    _initFxControls(root) {
+        const colorFolder = root.addFolder({ title: 'grading', expanded: false });
+        this._bind(colorFolder, this._ui.color, 'saturation', ['color', 'saturation'], { min: 0.0, max: 2.5, step: 0.01 });
+        this._bind(colorFolder, this._ui.color, 'contrast', ['color', 'contrast'], { min: 0.5, max: 2.5, step: 0.01 });
+        this._bind(colorFolder, this._ui.color, 'lift', ['color', 'lift'], { min: -0.5, max: 0.5, step: 0.005 });
+
+        const vignetteFolder = root.addFolder({ title: 'vignette', expanded: false });
+        this._bind(vignetteFolder, this._ui.vignette, 'enabled', ['vignette', 'enabled'], { label: 'enable' });
+        this._bind(vignetteFolder, this._ui.vignette, 'amount', ['vignette', 'amount'], { min: 0.0, max: 1.5, step: 0.01 });
+
+        const grainFolder = root.addFolder({ title: 'grain', expanded: false });
+        this._bind(grainFolder, this._ui.grain, 'enabled', ['grain', 'enabled'], { label: 'enable' });
+        this._bind(grainFolder, this._ui.grain, 'amount', ['grain', 'amount'], { min: 0.0, max: 0.5, step: 0.01 });
+
+        const chromaFolder = root.addFolder({ title: 'chromatic ab', expanded: false });
+        this._bind(chromaFolder, this._ui.chroma, 'enabled', ['chroma', 'enabled'], { label: 'enable' });
+        this._bind(chromaFolder, this._ui.chroma, 'amount', ['chroma', 'amount'], { min: 0.0, max: 0.01, step: 0.0001 });
+        chromaFolder.addBinding(this._ui.chroma, 'center', {
+            x: { min: 0.0, max: 1.0, step: 0.001 },
+            y: { min: 0.0, max: 1.0, step: 0.001 }
+        }).on('change', (ev) => {
+            const value = { x: clamp(ev.value.x, 0, 1), y: clamp(ev.value.y, 0, 1) };
+            postFxState.set(['chroma', 'center'], value);
+        });
+        this._bind(chromaFolder, this._ui.chroma, 'scale', ['chroma', 'scale'], { min: 0.2, max: 3.0, step: 0.01 });
+
+        const motionFolder = root.addFolder({ title: 'motion blur', expanded: false });
+        this._bind(motionFolder, this._ui.motion, 'enabled', ['motion', 'enabled'], { label: 'enable' });
+        this._bind(motionFolder, this._ui.motion, 'amount', ['motion', 'amount'], { min: 0.0, max: 1.0, step: 0.01 });
+    }
+
+    _initAdvanced(root) {
+        const aaFolder = root.addFolder({ title: 'anti aliasing', expanded: false });
+        aaFolder.addBlade({
+            view: 'list',
+            label: 'mode',
+            options: [
+                { text: 'off', value: 'off' },
+                { text: 'fxaa', value: 'fxaa' },
+                { text: 'smaa', value: 'smaa' },
+                { text: 'traa', value: 'traa' },
+            ],
+            value: this._ui.aa.mode,
+        }).on('change', (ev) => {
+            postFxState.set(['aa', 'mode'], ev.value);
+        });
+        this._bind(aaFolder, this._ui.aa, 'amount', ['aa', 'amount'], { min: 0.2, max: 2.0, step: 0.05, label: 'amount' });
+
+        const aoFolder = root.addFolder({ title: 'ambient occlusion', expanded: false });
+        this._bind(aoFolder, this._ui.ao, 'enabled', ['ao', 'enabled'], { label: 'enable' });
+        this._bind(aoFolder, this._ui.ao, 'radius', ['ao', 'radius'], { min: 0.05, max: 2.0, step: 0.01, label: 'radius' });
+        this._bind(aoFolder, this._ui.ao, 'thickness', ['ao', 'thickness'], { min: 0.1, max: 4.0, step: 0.05, label: 'thickness' });
+        this._bind(aoFolder, this._ui.ao, 'distanceExponent', ['ao', 'distanceExponent'], { min: 0.5, max: 3.0, step: 0.05, label: 'distance exp' });
+        this._bind(aoFolder, this._ui.ao, 'scale', ['ao', 'scale'], { min: 0.1, max: 2.0, step: 0.05 });
+        this._bind(aoFolder, this._ui.ao, 'samples', ['ao', 'samples'], { min: 4, max: 32, step: 1 });
+        this._bind(aoFolder, this._ui.ao, 'resolutionScale', ['ao', 'resolutionScale'], { min: 0.25, max: 1.0, step: 0.05, label: 'res scale' });
+
+        const ssrFolder = root.addFolder({ title: 'screen space reflections', expanded: false });
+        this._bind(ssrFolder, this._ui.ssr, 'enabled', ['ssr', 'enabled'], { label: 'enable' });
+        this._bind(ssrFolder, this._ui.ssr, 'opacity', ['ssr', 'opacity'], { min: 0.0, max: 1.0, step: 0.01 });
+        this._bind(ssrFolder, this._ui.ssr, 'maxDistance', ['ssr', 'maxDistance'], { min: 0.1, max: 5.0, step: 0.01, label: 'distance' });
+        this._bind(ssrFolder, this._ui.ssr, 'thickness', ['ssr', 'thickness'], { min: 0.01, max: 1.0, step: 0.01 });
+        this._bind(ssrFolder, this._ui.ssr, 'resolutionScale', ['ssr', 'resolutionScale'], { min: 0.25, max: 1.0, step: 0.05, label: 'res scale' });
+        this._bind(ssrFolder, this._ui.ssr, 'metalness', ['ssr', 'metalness'], { min: 0.0, max: 1.5, step: 0.01 });
+    }
+
+    init(position = 'left') {
+        if (this.gui) return this.gui;
+        const container = document.createElement('div');
+        container.style.position = 'absolute';
+        container.style.top = '16px';
+        container.style.left = position === 'left' ? '16px' : 'auto';
+        container.style.right = position === 'right' ? '16px' : 'auto';
+        container.style.maxWidth = '360px';
+        container.style.padding = '8px';
+        container.style.borderRadius = '12px';
+        container.style.background = 'rgba(16, 20, 24, 0.32)';
+        container.style.backdropFilter = 'blur(12px) saturate(160%)';
+        container.style.WebkitBackdropFilter = 'blur(12px) saturate(160%)';
+        container.style.border = '1px solid rgba(255,255,255,0.14)';
+        container.style.boxShadow = '0 12px 32px rgba(0,0,0,0.35)';
+        container.style.pointerEvents = 'auto';
+        document.body.appendChild(container);
+        this._container = container;
+
+        const pane = new Pane({ container });
+        pane.registerPlugin(EssentialsPlugin);
+        this.gui = pane;
+
+        pane.addBinding(this._ui, 'enabled', { label: 'enable post fx' }).on('change', (ev) => {
+            postFxState.set('enabled', ev.value);
+        });
+
+        const sections = pane.addFolder({ title: 'pipeline', expanded: true });
+        this._initCameraControls(sections);
+        this._initLensControls(sections);
+        this._initDofControls(sections);
+        this._initBloomControls(sections);
+        this._initFxControls(sections);
+        this._initAdvanced(sections);
+
+        pane.addBlade({ view: 'button', label: 'reset', title: 'Reset to defaults' }).on('click', () => {
+            postFxState.reset();
+        });
+
+        this._unsubscribe = postFxState.subscribe((state) => {
+            syncStateObject(this._ui, state);
+            if (this.gui) this.gui.refresh();
+        });
+
+        return pane;
+    }
+
+    dispose() {
+        if (this._unsubscribe) this._unsubscribe();
+        this._unsubscribe = null;
+        if (this.gui) {
+            this.gui.dispose();
+            this.gui = null;
+        }
+        if (this._container && this._container.parentElement) {
+            this._container.parentElement.removeChild(this._container);
+        }
+        this._container = null;
+    }
+}
+
+export default PostFXPanel;
+

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,8 @@ import AudioEngine from "./audio/audio.js";
 import AudioRouter from "./audio/audioRouter.js";
 import AudioPanel from "./audio/audioPanel.js";
 import LensPipeline from "./postfx/cameraLens.js";
+import { postFxState } from "./postfx/state.js";
+import PostFXPanel from "./io/postfxPanel.js";
 // PostFX pipeline is initialized dynamically inside init
 
 // Stage handles camera/scene/environment & controls
@@ -27,6 +29,7 @@ class App {
     lens = null;
     router = null;
     audioPanel = null;
+    postFxPanel = null;
 
     constructor(renderer) {
         this.renderer = renderer;
@@ -39,7 +42,8 @@ class App {
         this.stage = new Stage(this.renderer);
         await this.stage.init(progressCallback);
         // Store environment rotation base for audio sway
-        this._envBase = { bg: conf.bgRotY, env: conf.envRotY };
+        const camState = postFxState.value.camera;
+        this._envBase = { bg: camState.bgRotation, env: camState.envRotation };
 
         await progressCallback(0.5)
 
@@ -200,6 +204,8 @@ class App {
         this.postFX = new (await import('./postfx/postfx.js')).default(this.renderer);
         await this.postFX.init(this.stage);
         this.lens = new LensPipeline(this.stage, this.postFX);
+        this.postFxPanel = new PostFXPanel(this.lens);
+        this.postFxPanel.init('left');
 
 
         this.raycaster = new THREE.Raycaster();
@@ -246,7 +252,8 @@ class App {
         this.mlsMpmSim.setMouseRay(originSim, dirSim, posSim);
 
         // Auto focus DOF to pointer via LensPipeline
-        if (conf.dofEnabled && conf.dofAutoFocus && this.lens) {
+        const fxState = postFxState.value;
+        if (fxState.dof.enabled && fxState.dof.autoFocus && this.lens) {
             const camSpace = intersect.clone().applyMatrix4(camera.matrixWorldInverse);
             const viewDist = Math.abs(camSpace.z);
             this.lens.onPointerFocus(viewDist);
@@ -309,19 +316,21 @@ class App {
         } else {
             conf._audioLevel = conf._audioBeat = conf._audioBass = conf._audioMid = conf._audioTreble = 0;
             // Reset environment rotations when audio off
-            if (this._envBase) { conf.bgRotY = this._envBase.bg; conf.envRotY = this._envBase.env; }
+            if (this._envBase) {
+                postFxState.set(['camera', 'bgRotation'], this._envBase.bg);
+                postFxState.set(['camera', 'envRotation'], this._envBase.env);
+            }
         }
 
         await this.mlsMpmSim.update(delta,elapsed);
 
         // Sync post FX from control panel and motion direction
-        if (this.postFX) this.postFX.updateFromConf(conf);
         if (this.lens) this.lens.update();
         if (!this._prevCamPos) this._prevCamPos = this.stage.camera.position.clone();
         if (this.postFX) this.postFX.updateMotionDirection(this.stage.camera, this._prevCamPos);
         this._prevCamPos.copy(this.stage.camera.position);
 
-        if (conf.postFxEnabled && this.postFX) {
+        if (postFxState.value.enabled && this.postFX) {
             await this.postFX.renderAsync();
         } else {
             await this.renderer.renderAsync(this.stage.scene, this.stage.camera);

--- a/src/postfx/cameraLens.js
+++ b/src/postfx/cameraLens.js
@@ -1,5 +1,5 @@
 import * as THREE from "three/webgpu";
-import { conf } from "../config.js";
+import { postFxState } from "./state.js";
 
 // Centralizes camera + lens + DOF control
 // - Maps physical-ish lens params -> DOF controls
@@ -10,7 +10,8 @@ export default class LensPipeline {
   constructor(stage, postFX) {
     this.stage = stage;
     this.postFX = postFX;
-    this._focus = conf.dofFocus || 1.0;
+    this.state = postFxState;
+    this._focus = this.state.value.dof.focus || 1.0;
   }
 
   // Convert sensor/focal to vertical FOV in degrees
@@ -24,29 +25,32 @@ export default class LensPipeline {
 
   _applyLensToCamera() {
     if (!this.stage || !this.stage.camera) return;
-    if (conf.lensEnabled && conf.lensDriveFov) {
-      const fov = this._focalToFov(conf.sensorWidth || 36.0, conf.focalLength || 35.0);
-      conf.fov = Math.max(10, Math.min(140, fov));
+    const { lens } = this.state.value;
+    if (lens.enabled && lens.driveFov) {
+      const fov = this._focalToFov(lens.sensorWidth || 36.0, lens.focalLength || 35.0);
+      this.state.set(['camera', 'fov'], THREE.MathUtils.clamp(fov, 10, 140));
     }
   }
 
   _mapLensToDOF() {
-    if (!conf.lensEnabled) return;
-    const crop = 36.0 / Math.max(1e-3, conf.sensorWidth || 36.0);
-    const focal = conf.focalLength || 35.0;
-    const N = Math.max(0.1, conf.fStop || 2.8);
+    const { lens } = this.state.value;
+    if (!lens.enabled) return;
+    const crop = 36.0 / Math.max(1e-3, lens.sensorWidth || 36.0);
+    const focal = lens.focalLength || 35.0;
+    const N = Math.max(0.1, lens.fStop || 2.8);
     const blurProxy = (focal / N) * crop; // larger == stronger blur
-    conf.dofAmount = Math.max(0.2, Math.min(2.0, blurProxy * 0.02));
-    conf.dofRange = Math.max(0.02, Math.min(2.0, blurProxy * 0.015));
-    conf.dofFarBoost = Math.max(1.0, Math.min(3.0, blurProxy * 0.03));
-    conf.dofNearBoost = Math.max(0.8, Math.min(2.0, blurProxy * 0.015));
+    this.state.set(['dof', 'amount'], THREE.MathUtils.clamp(blurProxy * 0.02, 0.2, 2.0));
+    this.state.set(['dof', 'range'], THREE.MathUtils.clamp(blurProxy * 0.015, 0.02, 2.0));
+    this.state.set(['dof', 'farBoost'], THREE.MathUtils.clamp(blurProxy * 0.03, 1.0, 3.0));
+    this.state.set(['dof', 'nearBoost'], THREE.MathUtils.clamp(blurProxy * 0.015, 0.8, 2.0));
   }
 
   onPointerFocus(viewDist) {
     // Feed smoothed focus distance to PostFX
-    const s = Math.max(0.0, Math.min(1.0, conf.focusSmooth || 0.2));
+    const { lens, dof } = this.state.value;
+    const s = THREE.MathUtils.clamp(lens.focusSmooth ?? 0.2, 0.0, 1.0);
     this._focus = this._focus * (1 - s) + Math.abs(viewDist) * s;
-    if (this.postFX && conf.dofAutoFocus) this.postFX.setFocusDistance(this._focus, 0);
+    if (this.postFX && dof.autoFocus) this.postFX.setFocusDistance(this._focus, 0);
   }
 
   update() {

--- a/src/postfx/postfx.js
+++ b/src/postfx/postfx.js
@@ -5,18 +5,21 @@ import { bloom } from 'three/examples/jsm/tsl/display/BloomNode.js';
 import GTAONode from 'three/examples/jsm/tsl/display/GTAONode.js';
 import SMAANode from 'three/examples/jsm/tsl/display/SMAANode.js';
 import SSRNode from 'three/examples/jsm/tsl/display/SSRNode.js';
+import { postFxState } from './state.js';
 
 class PostFX {
   constructor(renderer) {
     this.renderer = renderer;
     this.postProcessing = null;
     this._built = false;
+    this.state = postFxState;
+    this._stateVersionApplied = -1;
   }
 
   async init(stage) {
     const scenePass = pass(stage.scene, stage.camera);
     // Include normal buffer for AO and future stages
-    scenePass.setMRT( mrt( { output, normal: normalView, velocity: velocity, bloomIntensity: float( 0 ) } ) );
+    scenePass.setMRT( mrt( { output, normal: normalView, velocity: velocity } ) );
     const outputPass = scenePass.getTextureNode();
     const viewZ = scenePass.getViewZNode( 'depth' );
     const normalTex = scenePass.getTextureNode( 'normal' );
@@ -27,7 +30,6 @@ class PostFX {
 
     // DOF
     this._dofEnabled = uniform( 1 );
-    this._dofHQ = uniform( 1 );
     this._dofFocusDist = uniform( 1.0 );
     this._dofFocal = uniform( 0.3 );
     this._dofBokeh = uniform( 0.8 );
@@ -58,9 +60,9 @@ class PostFX {
     const dofOut = this._dofNode.getTextureNode();
 
     // Bloom
-    const bloomIntensityPass = scenePass.getTextureNode( 'bloomIntensity' );
-    const bloomPass = bloom( outputPass.mul( bloomIntensityPass ) );
+    const bloomPass = bloom( outputPass );
     this.bloomPass = bloomPass;
+    this._bloomMix = uniform( 1.0 );
 
     // GTAO (optional)
     this._aoEnabled = uniform( 0 );
@@ -136,7 +138,7 @@ class PostFX {
       outCol = mix( outCol, smooth, q.mul(0.65) );
 
       // Bloom
-      outCol = outCol.add( bloomPass.rgb.clamp(0,1).mul(0.35) ).clamp(0,1);
+      outCol = outCol.add( bloomPass.rgb.clamp(0,1).mul( this._bloomMix ) ).clamp(0,1);
 
       // Vignette
       const st = uv();
@@ -194,16 +196,19 @@ class PostFX {
     // We'll create CA/Film on demand in renderAsync to ensure correct ordering
     this._smaa = null;
 
+    this._applyState();
     this._built = true;
   }
 
   setFocusDistance(d, smooth = 0) {
     if (!this._built) return;
-    if (smooth > 0 && this._dofFocusDist) {
-      this._dofFocusDist.value = this._dofFocusDist.value * (1 - smooth) + d * smooth;
-    } else if (this._dofFocusDist) {
-      this._dofFocusDist.value = d;
+    if (!this._dofFocusDist) return;
+    let next = d;
+    if (smooth > 0) {
+      next = this._dofFocusDist.value * (1 - smooth) + d * smooth;
     }
+    this._dofFocusDist.value = next;
+    this.state.set(['dof', 'focus'], next, { notify: true });
   }
 
   resize(width, height) {
@@ -213,68 +218,81 @@ class PostFX {
     if (this._gtao) this._gtao.setSize(width, height);
   }
 
-  updateFromConf(conf) {
+  _applyState() {
     if (!this._built) return;
-    // Bloom
+    const state = this.state.value;
+
+    const { bloom: bloomState, dof, vignette, grain, chroma, motion, color, aa, ao, ssr } = state;
+
     if (this.bloomPass) {
-      this.bloomPass.threshold.value = conf.bloomThreshold;
-      this.bloomPass.strength.value = conf.bloom ? conf.bloomStrength : 0.0;
-      this.bloomPass.radius.value = conf.bloomRadius;
+      this.bloomPass.threshold.value = bloomState.threshold;
+      this.bloomPass.radius.value = bloomState.radius;
+      this.bloomPass.strength.value = bloomState.strength;
     }
-    // DOF
-    this._dofEnabled.value = conf.dofEnabled ? 1 : 0;
-    this._dofHQ.value = conf.dofHighQuality ? 1 : 0;
-    if (!conf.dofAutoFocus) this._dofFocusDist.value = conf.dofFocus;
-    this._dofFocal.value = conf.dofRange;
-    this._dofBokeh.value = conf.dofAmount;
-    this._dofNearBoost.value = conf.dofNearBoost || 1.0;
-    this._dofFarBoost.value = conf.dofFarBoost || 1.0;
-    this._dofHiThresh.value = conf.dofHighlightThreshold || 0.8;
-    this._dofHiGain.value = conf.dofHighlightGain || 0.6;
-    this._apertureBlades.value = conf.apertureBlades || 7;
-    this._apertureRot.value = conf.apertureRotation || 0.0;
-    this._aperturePetal.value = conf.aperturePetal || 1.0;
-    this._anamorphic.value = conf.anamorphic || 0.0;
-    // Extras
-    this._vigEnabled.value = conf.vignetteEnabled ? 1 : 0;
-    this._vigAmount.value = conf.vignetteAmount;
-    this._grainEnabled.value = conf.grainEnabled ? 1 : 0;
-    this._grainAmount.value = conf.grainAmount;
-    this._chromaEnabled.value = conf.chromaEnabled ? 1 : 0;
-    this._chromaAmount.value = conf.chromaAmount;
-    if (conf.chromaCenter) this._chromaCenter.value.set(conf.chromaCenter.x, conf.chromaCenter.y);
-    this._chromaScale.value = conf.chromaScale || 1.0;
-    this._mbEnabled.value = conf.motionBlurEnabled ? 1 : 0;
-    this._mbAmount.value = conf.motionBlurAmount;
-    this._sat.value = conf.postSaturation || 1.0;
-    this._contrast.value = conf.postContrast || 1.0;
-    this._lift.value = conf.postLift || 0.0;
-    // 0 off, 1 fxaa, 2 smaa
+    this._bloomMix.value = bloomState.enabled ? bloomState.strength : 0.0;
+
+    this._dofEnabled.value = dof.enabled ? 1 : 0;
+    if (!dof.autoFocus) this._dofFocusDist.value = dof.focus;
+    this._dofFocal.value = dof.range;
+    this._dofBokeh.value = dof.amount;
+    this._dofNearBoost.value = dof.nearBoost;
+    this._dofFarBoost.value = dof.farBoost;
+    this._dofHiThresh.value = dof.highlightThreshold;
+    this._dofHiGain.value = dof.highlightGain;
+    this._apertureBlades.value = dof.apertureBlades;
+    this._apertureRot.value = dof.apertureRotation;
+    this._aperturePetal.value = dof.aperturePetal;
+    this._anamorphic.value = dof.anamorphic;
+    const dofQuality = typeof dof.quality === 'number' ? dof.quality : (dof.highQuality ? 1.0 : 0.6);
+    this._dofQualityU.value = dofQuality;
+
+    this._vigEnabled.value = vignette.enabled ? 1 : 0;
+    this._vigAmount.value = vignette.amount;
+    this._grainEnabled.value = grain.enabled ? 1 : 0;
+    this._grainAmount.value = grain.amount;
+    this._chromaEnabled.value = chroma.enabled ? 1 : 0;
+    this._chromaAmount.value = chroma.amount;
+    if (chroma.center) this._chromaCenter.value.set(chroma.center.x, chroma.center.y);
+    this._chromaScale.value = chroma.scale;
+    this._mbEnabled.value = motion.enabled ? 1 : 0;
+    this._mbAmount.value = motion.amount;
+    this._sat.value = color.saturation;
+    this._contrast.value = color.contrast;
+    this._lift.value = color.lift;
+
     let aaMode = 0;
-    if (conf.aaMode === 'fxaa') aaMode = 1; else if (conf.aaMode === 'smaa') aaMode = 2; else if (conf.aaMode === 'traa') aaMode = 1;
+    if (aa.mode === 'fxaa') aaMode = 1;
+    else if (aa.mode === 'smaa') aaMode = 2;
+    else if (aa.mode === 'traa') aaMode = 1;
     this._aaMode.value = aaMode;
-    this._aaAmount.value = conf.aaAmount || 1.0;
-    this._dofQualityU.value = conf.dofQuality || 1.0;
-    // AO
-    this._aoEnabled.value = conf.gtaoEnabled ? 1 : 0;
+    this._aaAmount.value = aa.amount;
+
+    this._aoEnabled.value = ao.enabled ? 1 : 0;
     if (this._gtao) {
-      this._gtao.radius.value = conf.gtaoRadius;
-      this._gtao.thickness.value = conf.gtaoThickness;
-      this._gtao.distanceExponent.value = conf.gtaoDistanceExponent;
-      this._gtao.scale.value = conf.gtaoScale;
-      this._gtao.samples.value = conf.gtaoSamples;
-      this._gtao.resolutionScale = conf.gtaoResolutionScale;
+      this._gtao.radius.value = ao.radius;
+      this._gtao.thickness.value = ao.thickness;
+      this._gtao.distanceExponent.value = ao.distanceExponent;
+      this._gtao.scale.value = ao.scale;
+      this._gtao.samples.value = ao.samples;
+      this._gtao.resolutionScale = ao.resolutionScale;
     }
-    // SSGI placeholder
+
     this._ssgiEnabled.value = 0;
-    // SSR
-    this._ssrEnabled.value = conf.ssrEnabled ? 1 : 0;
+    this._ssrEnabled.value = ssr.enabled ? 1 : 0;
     if (this._ssr) {
-      this._ssr.opacity.value = conf.ssrOpacity;
-      this._ssr.maxDistance.value = conf.ssrMaxDistance;
-      this._ssr.thickness.value = conf.ssrThickness;
-      this._ssr.resolutionScale = conf.ssrResolutionScale;
-      this._ssrMetalness.value = conf.ssrMetalness;
+      this._ssr.opacity.value = ssr.opacity;
+      this._ssr.maxDistance.value = ssr.maxDistance;
+      this._ssr.thickness.value = ssr.thickness;
+      this._ssr.resolutionScale = ssr.resolutionScale;
+      this._ssrMetalness.value = ssr.metalness;
+    }
+
+    this._stateVersionApplied = this.state.version;
+  }
+
+  _ensureStateApplied() {
+    if (this._stateVersionApplied !== this.state.version) {
+      this._applyState();
     }
   }
 
@@ -289,6 +307,7 @@ class PostFX {
 
   async renderAsync() {
     if (!this.postProcessing) return;
+    this._ensureStateApplied();
     // Build CA/Film chain on top of composed tex
     let node = this._finalNodeTex;
     // Chromatic aberration
@@ -296,7 +315,7 @@ class PostFX {
       const { vec2, float } = await import('three/tsl'); // dynamic import for literal nodes
       const caNodeMod = await import('three/examples/jsm/tsl/display/ChromaticAberrationNode.js');
       const CAClass = caNodeMod.default;
-      node = new CAClass( node, this._chromaAmount, vec2(0.5,0.5), float(1.0) );
+      node = new CAClass( node, this._chromaAmount, vec2(this._chromaCenter.value.x, this._chromaCenter.value.y), float(this._chromaScale.value) );
     }
     // Film grain
     if (this._grainEnabled.value > 0.5) {

--- a/src/postfx/state.js
+++ b/src/postfx/state.js
@@ -1,0 +1,184 @@
+const DEFAULTS = {
+  enabled: true,
+  camera: {
+    fov: 60,
+    exposure: 0.66,
+    envIntensity: 0.5,
+    bgRotation: 2.15,
+    envRotation: -2.15,
+  },
+  lens: {
+    enabled: false,
+    sensorWidth: 36.0,
+    focalLength: 24.0,
+    fStop: 1.8,
+    driveFov: true,
+    focusSmooth: 0.2,
+  },
+  dof: {
+    enabled: true,
+    autoFocus: true,
+    focus: 0.8,
+    range: 0.08,
+    amount: 1.15,
+    highQuality: true,
+    quality: 1.0,
+    nearBoost: 1.0,
+    farBoost: 1.0,
+    highlightThreshold: 0.8,
+    highlightGain: 0.6,
+    apertureBlades: 7,
+    apertureRotation: 0.0,
+    aperturePetal: 1.0,
+    anamorphic: 0.0,
+  },
+  bloom: {
+    enabled: true,
+    strength: 1.2,
+    radius: 1.0,
+    threshold: 0.0005,
+  },
+  vignette: {
+    enabled: false,
+    amount: 0.25,
+  },
+  grain: {
+    enabled: false,
+    amount: 0.08,
+  },
+  chroma: {
+    enabled: false,
+    amount: 0.0025,
+    center: { x: 0.5, y: 0.5 },
+    scale: 1.0,
+  },
+  motion: {
+    enabled: false,
+    amount: 0.35,
+  },
+  color: {
+    saturation: 1.0,
+    contrast: 1.0,
+    lift: 0.0,
+  },
+  aa: {
+    mode: 'off',
+    amount: 1.0,
+  },
+  ao: {
+    enabled: false,
+    radius: 0.25,
+    thickness: 1.0,
+    distanceExponent: 1.0,
+    scale: 1.0,
+    samples: 16,
+    resolutionScale: 1.0,
+  },
+  ssr: {
+    enabled: false,
+    opacity: 0.2,
+    maxDistance: 1.0,
+    thickness: 0.1,
+    resolutionScale: 0.75,
+    metalness: 0.8,
+  },
+};
+
+const clone = (value) => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+};
+
+const assignDeep = (target, source) => {
+  Object.keys(target).forEach((key) => {
+    if (!(key in source)) delete target[key];
+  });
+  Object.entries(source).forEach(([key, value]) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      if (!target[key] || typeof target[key] !== 'object') {
+        target[key] = Array.isArray(value) ? [] : {};
+      }
+      assignDeep(target[key], value);
+    } else {
+      target[key] = value;
+    }
+  });
+  return target;
+};
+
+class PostFXState {
+  constructor(defaults) {
+    this._defaults = clone(defaults);
+    this._state = clone(defaults);
+    this._listeners = new Set();
+    this.version = 0;
+  }
+
+  get value() {
+    return this._state;
+  }
+
+  snapshot() {
+    return clone(this._state);
+  }
+
+  reset() {
+    this._state = clone(this._defaults);
+    this._emit();
+  }
+
+  set(path, value, { notify = true } = {}) {
+    if (!path) return;
+    const segments = Array.isArray(path) ? path : `${path}`.split('.');
+    const last = segments[segments.length - 1];
+    let cursor = this._state;
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const key = segments[i];
+      if (!cursor[key] || typeof cursor[key] !== 'object') {
+        cursor[key] = {};
+      }
+      cursor = cursor[key];
+    }
+    const current = cursor[last];
+    const nextValue = value && typeof value === 'object' && !Array.isArray(value)
+      ? clone(value)
+      : value;
+    const same = (typeof current === 'object' && typeof nextValue === 'object')
+      ? JSON.stringify(current) === JSON.stringify(nextValue)
+      : current === nextValue;
+    if (same) return;
+    cursor[last] = nextValue;
+    if (notify) this._emit();
+  }
+
+  update(partial) {
+    assignDeep(this._state, { ...this._state, ...partial });
+    this._emit();
+  }
+
+  subscribe(listener) {
+    this._listeners.add(listener);
+    return () => {
+      this._listeners.delete(listener);
+    };
+  }
+
+  _emit() {
+    this.version += 1;
+    const snapshot = this.snapshot();
+    this._listeners.forEach((fn) => {
+      try {
+        fn(snapshot, this.version);
+      } catch (err) {
+        console.warn('postFxState listener error', err);
+      }
+    });
+  }
+}
+
+export const postFxState = new PostFXState(DEFAULTS);
+export const POST_FX_DEFAULTS = clone(DEFAULTS);
+export const syncStateObject = assignDeep;
+

--- a/src/renders/glyphRenderer.js
+++ b/src/renders/glyphRenderer.js
@@ -1,5 +1,5 @@
 import * as THREE from "three/webgpu";
-import { Fn, attribute, instanceIndex, mat3, normalize, vec3, varying, uniform, mrt, float } from "three/tsl";
+import { Fn, attribute, instanceIndex, mat3, normalize, vec3, varying, uniform, float } from "three/tsl";
 import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { conf } from "../config.js";
 import { calcLookAtMatrix } from "./particleRenderer";
@@ -7,7 +7,6 @@ import { calcLookAtMatrix } from "./particleRenderer";
 class GlyphRenderer {
     mlsMpmSim = null;
     object = null;
-    bloom = false;
     uniforms = {};
 
     constructor(mlsMpmSim) {
@@ -57,14 +56,9 @@ class GlyphRenderer {
     }
 
     update() {
-        const { particles, bloom, actualSize, worldScale, zScale } = conf;
+        const { particles, actualSize, worldScale, zScale } = conf;
         this.uniforms.size.value = actualSize;
         this.geometry.instanceCount = particles;
-
-        if (bloom !== this.bloom) {
-            this.bloom = bloom;
-            this.material.mrtNode = bloom ? mrt({ bloomIntensity: 1 }) : null;
-        }
 
         const s = (1/64) * (worldScale || 1);
         this.object.position.set(0,0,0);

--- a/src/renders/particleRenderer.js
+++ b/src/renders/particleRenderer.js
@@ -1,5 +1,5 @@
 import * as THREE from "three/webgpu";
-import {Fn, attribute, triNoise3D, time, vec3, vec4, float, varying,instanceIndex,mix,normalize,cross,mat3,normalLocal,transformNormalToView,mx_hsvtorgb,mrt,uniform} from "three/tsl";
+import {Fn, attribute, triNoise3D, time, vec3, vec4, float, varying,instanceIndex,mix,normalize,cross,mat3,normalLocal,transformNormalToView,mx_hsvtorgb,uniform} from "three/tsl";
 import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { conf } from "../config.js";
 
@@ -92,7 +92,6 @@ const createRoundedBox = (width, height, depth, radius) => {
 class ParticleRenderer {
     mlsMpmSim = null;
     object = null;
-    bloom = false;
     uniforms = {};
 
     constructor(mlsMpmSim) {
@@ -173,17 +172,10 @@ class ParticleRenderer {
     }
 
     update() {
-        const { particles, bloom, actualSize, worldScale, zScale } = conf;
+        const { particles, actualSize, worldScale, zScale } = conf;
         this.uniforms.size.value = actualSize;
         this.uniforms.zScale.value = zScale;
         this.geometry.instanceCount = particles;
-
-        if (bloom !== this.bloom) {
-            this.bloom = bloom;
-            this.material.mrtNode = bloom ? mrt( {
-                bloomIntensity: 1
-            } ) : null;
-        }
 
         // Fit domain to view by scaling the 64^3 to world mapping
         const s = (1/64) * (worldScale || 1);

--- a/src/stage/stage.js
+++ b/src/stage/stage.js
@@ -1,6 +1,7 @@
 import * as THREE from "three/webgpu";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { conf } from "../config.js";
+import { postFxState } from "../postfx/state.js";
 import { loadHdrTexture } from "../commons/assets.js";
 import { Lights } from "./lights.js";
 import hdri from "../assets/autumn_field_puresky_1k.hdr";
@@ -19,7 +20,8 @@ export class Stage {
     async init( progressCallback ) {
         if ( progressCallback ) await progressCallback( 0.05 );
 
-        this.camera = new THREE.PerspectiveCamera( conf.fov, window.innerWidth / window.innerHeight, 0.01, 10 );
+        const camState = postFxState.value.camera;
+        this.camera = new THREE.PerspectiveCamera( camState.fov, window.innerWidth / window.innerHeight, 0.01, 10 );
         this.camera.position.set( 0, 0, 2.0 );
         this.camera.updateProjectionMatrix();
 
@@ -43,7 +45,7 @@ export class Stage {
 
         this.applyEnvironmentParams();
 
-        this.renderer.toneMappingExposure = conf.exposure;
+        this.renderer.toneMappingExposure = camState.exposure;
         this.renderer.shadowMap.enabled = true;
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
@@ -54,9 +56,10 @@ export class Stage {
     }
 
     applyEnvironmentParams() {
-        this.scene.backgroundRotation = new THREE.Euler( 0, conf.bgRotY, 0 );
-        this.scene.environmentRotation = new THREE.Euler( 0, conf.envRotY, 0 );
-        this.scene.environmentIntensity = conf.envIntensity;
+        const camState = postFxState.value.camera;
+        this.scene.backgroundRotation = new THREE.Euler( 0, camState.bgRotation, 0 );
+        this.scene.environmentRotation = new THREE.Euler( 0, camState.envRotation, 0 );
+        this.scene.environmentIntensity = camState.envIntensity;
     }
 
     resize( width, height ) {
@@ -66,13 +69,14 @@ export class Stage {
 
     update( delta, elapsed ) {
         // Live-sync camera and environment parameters from control panel
-        if ( Math.abs( this.camera.fov - conf.fov ) > 0.001 ) {
-            this.camera.fov = conf.fov;
+        const camState = postFxState.value.camera;
+        if ( Math.abs( this.camera.fov - camState.fov ) > 0.001 ) {
+            this.camera.fov = camState.fov;
             this.camera.updateProjectionMatrix();
         }
 
         this.applyEnvironmentParams();
-        this.renderer.toneMappingExposure = conf.exposure;
+        this.renderer.toneMappingExposure = camState.exposure;
 
         this.controls.update( delta );
         if ( this.lights && this.lights.update ) this.lights.update( elapsed );


### PR DESCRIPTION
## Summary
- replace scattered post-processing configuration with a centralized `postFxState` container and updated pipeline logic
- add a dedicated left-side PostFX panel for camera, lens, DOF, bloom, AA, and grading controls while pruning legacy dashboard bindings and config fields
- simplify renderers and presets by removing bloom mask dependencies and document the refactor plan in `POSTFX_PIPELINE_PLAN.md`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d644465af88327a4d095f754f27f81