### PR TITLE
Guard navigator usage in config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -254,6 +254,10 @@ const isMobile = (): boolean => {
     const mobile = require("is-mobile");
     return mobile();
   } catch {
+    // During SSR/tests `navigator` may be undefined; assume non-mobile in that case.
+    if (typeof navigator === "undefined" || !navigator?.userAgent) {
+      return false;
+    }
     return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
   }
 };


### PR DESCRIPTION
## Summary
- guard the fallback mobile detection logic against missing navigator
- document the SSR/test assumption when navigator is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e30f7d912c8327be832e25a6111636