### PR TITLE
feat: unify panels into adaptive dashboard

### DIFF
--- a/PANEL_VERTICAL_REDESIGN_PROPOSAL.md
+++ b/PANEL_VERTICAL_REDESIGN_PROPOSAL.md
@@ -1,0 +1,56 @@
+# Aurora Unified Control Surface Proposal
+
+## Objectives
+- Consolidate all control panels (Audio Reactivity, Post FX, Visuals, Physics, Theme Manager) into a single adaptive dashboard.
+- Deliver a vertical tab navigation that defaults to the right edge, supports collapse/expand animations, and can be re-docked to any screen edge via drag & drop.
+- Preserve Tweakpane workflows while upgrading to a refined glassmorphism system with consistent spacing, hierarchy, and iconography.
+- Introduce a theme & preset pipeline that manages palette, surface, typography, and glow variables across every panel.
+
+## Experience Pillars
+1. **Unified Navigation**
+   - Single dashboard shell with vertical tabs.
+   - Tab badges/icons for instant recognition.
+   - Smooth cross-fade between panels, preserving scroll position.
+2. **Adaptive Docking**
+   - Drag handle snaps shell to left, right, or bottom edge.
+   - Responsive layout adapts tab orientation (vertical ↔ horizontal) based on dock target.
+   - Resizable shell with inertial feel and eased transitions.
+3. **Glassmorphism 2.0**
+   - Frosted layers driven by CSS custom properties.
+   - Ambient glow, border light, and parallax hover effects.
+   - Harmonized typography scale and paddings for all Tweakpane folders.
+4. **Intelligent Theming**
+   - Theme Manager tab exposing curated presets (Aurora, Midnight, Solaris, Spectrum).
+   - Live editing of accent hues, blur, translucency, and lighting ratios.
+   - Preset lifecycle: save, rename, delete, set default (persisted to localStorage).
+5. **Information Density & Grouping**
+   - Re-grouped panels: Essentials, Dynamics, Advanced, Monitoring clusters.
+   - Contextual helper text using subtle infodumps.
+   - Quick actions area (reset, randomize, favorite presets).
+
+## Implementation Roadmap
+1. **Dashboard Shell**
+   - Replace legacy floating panels with `DashboardShell` featuring tab rail, panel viewport, collapse control, drag/dock logic, resize handle.
+   - Expose `registerPanel()` for panel modules; maintain plugin registration for Tweakpane.
+   - Inject modernized CSS with variables: `--aurora-glass-bg1`, `--aurora-glass-bg2`, `--aurora-accent`, etc.
+2. **Panel Migration**
+   - Relocate `PANELsoundreactivity`, `PANELpostfx`, `PANELphysic`, `PANELvisuals` into `src/PANEL/panels`.
+   - Update imports to consume the unified dashboard API.
+   - Restructure sections (folders, tabs) for clarity and balanced lengths.
+3. **Theme Pipeline**
+   - Introduce `ThemeManagerPanel` inside `src/PANEL/panels/theme.ts`.
+   - Define `DashboardTheme` interface & defaults within `dashboard.ts`.
+   - Implement preset storage, load/save operations, and global CSS variable updates.
+4. **UX Enhancements**
+   - Add micro-interactions: hover shimmer on tabs, slide-in/out collapse animation, focus ring for keyboard navigation.
+   - Provide aria attributes for accessibility.
+5. **Integration**
+   - Update `APP.ts` to register each panel via the new dashboard.
+   - Validate layout across docking positions; ensure responsiveness down to 1024px width.
+
+## Success Criteria
+- All control panels accessible through a single adaptive shell with zero overlapping windows by default.
+- Docking transitions are smooth (<200ms) with no layout flashes.
+- Theme changes propagate instantly to every panel without refresh.
+- Presets persist between sessions and can be restored via "Set as default".
+- Codebase reflects reorganized `src/PANEL` hierarchy.

--- a/src/APP.ts
+++ b/src/APP.ts
@@ -11,18 +11,19 @@ import { Dashboard } from './PANEL/dashboard';
 import { Scenery } from './STAGE/scenery';
 import { PostFX } from './POSTFX/postfx';  // RE-ENABLED (simplified version)
 import { ParticleBoundaries } from './PARTICLESYSTEM/physic/boundaries';
-import { PostFXPanel } from './POSTFX/PANELpostfx';  // RE-ENABLED
+import { PostFXPanel } from './PANEL/panels/postfx';  // RE-ENABLED
 import { MlsMpmSimulator } from './PARTICLESYSTEM/physic/mls-mpm';
 import { MeshRenderer } from './PARTICLESYSTEM/RENDERER/meshrenderer';
 import { PointRenderer } from './PARTICLESYSTEM/RENDERER/pointrenderer';
 import { RendererManager, ParticleRenderMode } from './PARTICLESYSTEM/RENDERER/renderercore';
-import { PhysicPanel, ColorMode } from './PARTICLESYSTEM/PANELphysic';
-import { VisualsPanel } from './PARTICLESYSTEM/PANEL/PANELvisuals';
+import { PhysicPanel, ColorMode } from './PANEL/panels/physics';
+import { VisualsPanel } from './PANEL/panels/visuals';
 import { SoundReactivity } from './AUDIO/soundreactivity';
 import type { AudioData } from './AUDIO/soundreactivity';
 import { AudioReactiveBehavior } from './AUDIO/audioreactive';
 import { AudioVisualizationManager } from './AUDIO/audiovisual';
-import { AudioPanel } from './AUDIO/PANELsoundreactivity';
+import { AudioPanel } from './PANEL/panels/audio';
+import { ThemeManagerPanel } from './PANEL/panels/theme';
 import { AdaptivePerformanceManager, type PerformanceChangeContext, type PerformanceTier } from './APP/performance';
 
 export type { ProgressCallback } from './APP/types';
@@ -58,6 +59,7 @@ export class FlowApp {
   private physicPanel!: PhysicPanel;
   private visualsPanel!: VisualsPanel;  // NEW: Visual controls
   private audioPanel!: AudioPanel;
+  private themePanel!: ThemeManagerPanel;
 
   // Audio reactivity
   private soundReactivity!: SoundReactivity;
@@ -277,6 +279,8 @@ export class FlowApp {
         this.postFX.updateRadialCA(radialCAConfig);
       },
     });
+
+    this.themePanel = new ThemeManagerPanel(this.dashboard);
   }
 
   private async initializeAudioSystems(): Promise<void> {

--- a/src/PANEL/dashboard.ts
+++ b/src/PANEL/dashboard.ts
@@ -1,6 +1,6 @@
 /**
- * PANEL/dashboard.ts - Glassmorphism-styled draggable panel system
- * Single responsibility: UI framework with beautiful, modular control panels
+ * PANEL/dashboard.ts - Unified adaptive dashboard with vertical tab navigation
+ * Provides glassmorphism styling, docking, collapse transitions, and theme pipeline
  */
 
 import { Pane } from 'tweakpane';
@@ -8,950 +8,985 @@ import * as EssentialsPlugin from '@tweakpane/plugin-essentials';
 import * as InfodumpPlugin from 'tweakpane-plugin-infodump';
 import type { FpsGraphBladeApi } from '@tweakpane/plugin-essentials/dist/types/fps-graph/api/fps-graph';
 
+export type DashboardDock = 'left' | 'right' | 'bottom';
+
 export interface DashboardOptions {
+  defaultDock?: DashboardDock;
+  collapsed?: boolean;
   showInfo?: boolean;
   showFPS?: boolean;
   enableGlassmorphism?: boolean;
 }
 
-export interface PanelConfig {
+export interface DashboardPanelOptions {
+  id: string;
   title: string;
-  position?: { x: number; y: number };
-  expanded?: boolean;
-  draggable?: boolean;
-  collapsible?: boolean;
+  icon?: string;
+  description?: string;
+  badge?: string;
 }
 
-/**
- * Dashboard - Advanced UI controller with glassmorphism styling
- * Manages multiple draggable, collapsible control panels
- */
-export class Dashboard {
-  private panels: Map<string, { pane: Pane; container: HTMLDivElement }> = new Map();
-  private fpsGraph: FpsGraphBladeApi | null = null;
-  private infoPane: Pane | null = null;
-  private styleSheet: HTMLStyleElement;
-  private enableGlassmorphism: boolean;
+export interface DashboardTheme {
+  accent: string; // HEX color
+  backgroundHue: number; // 0-360
+  backgroundSaturation: number; // 0-1
+  backgroundLightness: number; // 0-1
+  glassOpacity: number; // 0-1
+  glassBlur: number; // px
+  glassSaturation: number; // multiplier (1 = 100%)
+  glassBrightness: number; // multiplier (1 = 100%)
+  radius: number; // px
+  shadowStrength: number; // 0-1
+  highlightStrength: number; // 0-1
+  textBrightness: number; // 0-1
+}
 
-  constructor(options: DashboardOptions = {}) {
-    const { showInfo = true, showFPS = true, enableGlassmorphism = true } = options;
-    this.enableGlassmorphism = enableGlassmorphism;
+interface DashboardPanelInstance {
+  config: DashboardPanelOptions;
+  pane: Pane;
+  tab: HTMLButtonElement;
+  page: HTMLDivElement;
+}
 
-    // Inject glassmorphism styles IMMEDIATELY
-    this.styleSheet = this.injectStyles();
-    console.log('✨ Glassmorphism styles injected!', this.styleSheet.id);
+interface DragState {
+  pointerId: number;
+  offsetX: number;
+  offsetY: number;
+}
 
-    // Create FPS monitor panel (top-left, compact)
-    if (showFPS) {
-      this.createFPSPanel();
-    }
+interface ResizeState {
+  pointerId: number;
+  startWidth: number;
+  startHeight: number;
+  startX: number;
+  startY: number;
+}
 
-    // Create info panel (bottom-left)
-    if (showInfo) {
-      this.createInfoPanel();
+const DEFAULT_THEME: DashboardTheme = {
+  accent: '#7dd3ff',
+  backgroundHue: 218,
+  backgroundSaturation: 0.48,
+  backgroundLightness: 0.22,
+  glassOpacity: 0.78,
+  glassBlur: 42,
+  glassSaturation: 2.0,
+  glassBrightness: 1.12,
+  radius: 22,
+  shadowStrength: 0.9,
+  highlightStrength: 0.7,
+  textBrightness: 0.82,
+};
+
+const THEME_STORAGE_KEY = 'aurora.dashboard.theme.default';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const normalized = hex.replace('#', '');
+  const bigint = parseInt(normalized.length === 3
+    ? normalized.split('').map((c) => c + c).join('')
+    : normalized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return { r, g, b };
+}
+
+function hexToHsl(hex: string): { h: number; s: number; l: number } {
+  const { r, g, b } = hexToRgb(hex);
+  const rNorm = r / 255;
+  const gNorm = g / 255;
+  const bNorm = b / 255;
+
+  const max = Math.max(rNorm, gNorm, bNorm);
+  const min = Math.min(rNorm, gNorm, bNorm);
+  const delta = max - min;
+
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rNorm) {
+      h = ((gNorm - bNorm) / delta) % 6;
+    } else if (max === gNorm) {
+      h = (bNorm - rNorm) / delta + 2;
+    } else {
+      h = (rNorm - gNorm) / delta + 4;
     }
   }
 
-  /**
-   * Inject enhanced glassmorphism and draggable panel styles
-   */
+  const l = (max + min) / 2;
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+  const hue = Math.round(h * 60);
+  return { h: (hue + 360) % 360, s: Math.round(s * 100), l: Math.round(l * 100) };
+}
+
+function hslToCss(h: number, s: number, l: number, a = 1): string {
+  return `hsla(${Math.round(h)}, ${Math.round(s)}%, ${Math.round(l)}%, ${clamp(a, 0, 1)})`;
+}
+
+function mix(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+/**
+ * Dashboard - Adaptive container that orchestrates all control panels
+ */
+export class Dashboard {
+  private static pluginsRegistered = false;
+
+  private readonly styleSheet: HTMLStyleElement;
+  private readonly root: HTMLDivElement;
+  private readonly tabRail: HTMLDivElement;
+  private readonly tabList: HTMLDivElement;
+  private readonly panelViewport: HTMLDivElement;
+  private readonly collapseButton: HTMLButtonElement;
+  private readonly dragHandle: HTMLDivElement;
+  private readonly resizeHandle: HTMLDivElement;
+
+  private readonly panels = new Map<string, DashboardPanelInstance>();
+  private activePanelId: string | null = null;
+  private collapsed = false;
+  private dock: DashboardDock;
+  private dragState: DragState | null = null;
+  private resizeState: ResizeState | null = null;
+  private readonly sideSize = { width: 360, height: 620 };
+  private readonly sideSizeLimits = { width: [320, 460] as [number, number], height: [420, 760] as [number, number] };
+  private readonly bottomSize = { width: 720, height: 360 };
+  private readonly bottomSizeLimits = { width: [560, 960] as [number, number], height: [280, 520] as [number, number] };
+  private sideOffsetTop = 96;
+  private readonly sideInset = 24;
+  private theme: DashboardTheme;
+  private fpsGraph: FpsGraphBladeApi | null = null;
+
+  constructor(options: DashboardOptions = {}) {
+    if (!Dashboard.pluginsRegistered) {
+      Pane.registerPlugin(EssentialsPlugin);
+      Pane.registerPlugin(InfodumpPlugin);
+      Dashboard.pluginsRegistered = true;
+    }
+
+    this.theme = this.loadPersistedTheme() ?? { ...DEFAULT_THEME };
+    this.dock = options.defaultDock ?? 'right';
+
+    this.styleSheet = this.injectStyles();
+    this.root = this.createRoot();
+    this.tabRail = this.createTabRail();
+    this.tabList = this.createTabList();
+    this.collapseButton = this.createCollapseButton();
+    this.dragHandle = this.createDragHandle();
+    this.panelViewport = this.createPanelViewport();
+    this.resizeHandle = this.createResizeHandle();
+
+    this.tabRail.appendChild(this.dragHandle);
+    this.tabRail.appendChild(this.tabList);
+    this.tabRail.appendChild(this.collapseButton);
+
+    this.root.appendChild(this.tabRail);
+    this.root.appendChild(this.panelViewport);
+    this.root.appendChild(this.resizeHandle);
+
+    document.body.appendChild(this.root);
+
+    this.applyDock(this.dock);
+    if (options.collapsed) {
+      this.collapse();
+    }
+
+    if (options.showFPS) {
+      this.createPerformancePanel();
+    }
+    if (options.showInfo) {
+      this.createInfoPanel();
+    }
+
+    this.applyTheme(this.theme, false);
+  }
+
+  /** Register a panel and return its Tweakpane instance */
+  public registerPanel(options: DashboardPanelOptions): Pane {
+    if (this.panels.has(options.id)) {
+      throw new Error(`Panel with id "${options.id}" already exists.`);
+    }
+
+    const page = document.createElement('div');
+    page.className = 'aurora-panel-page';
+    page.dataset.panelId = options.id;
+    page.setAttribute('role', 'tabpanel');
+    page.setAttribute('aria-hidden', 'true');
+    this.panelViewport.appendChild(page);
+
+    const pane = new Pane({
+      container: page,
+      title: options.title,
+    });
+    pane.element.classList.add('aurora-pane');
+
+    const tab = document.createElement('button');
+    tab.type = 'button';
+    tab.className = 'aurora-tab';
+    tab.dataset.panelId = options.id;
+    tab.setAttribute('role', 'tab');
+    tab.setAttribute('aria-selected', 'false');
+    tab.innerHTML = `
+      <span class="aurora-tab-icon">${options.icon ?? '⬡'}</span>
+      <span class="aurora-tab-label">${options.title}</span>
+      <span class="aurora-tab-badge"></span>
+    `;
+    if (options.description) {
+      tab.title = options.description;
+    }
+    tab.addEventListener('click', () => this.activatePanel(options.id));
+    this.tabList.appendChild(tab);
+
+    const instance: DashboardPanelInstance = { config: options, pane, tab, page };
+    this.panels.set(options.id, instance);
+
+    if (!this.activePanelId) {
+      this.activatePanel(options.id);
+    }
+
+    this.updateTabOrientation();
+    return pane;
+  }
+
+  /** Activate a panel by id */
+  public activatePanel(id: string): void {
+    const target = this.panels.get(id);
+    if (!target) {
+      console.warn(`[Dashboard] Panel "${id}" not found.`);
+      return;
+    }
+    if (this.activePanelId === id) {
+      this.expand();
+      return;
+    }
+
+    this.panels.forEach((panel, panelId) => {
+      const active = panelId === id;
+      panel.page.classList.toggle('is-active', active);
+      panel.page.setAttribute('aria-hidden', active ? 'false' : 'true');
+      panel.tab.classList.toggle('is-active', active);
+      panel.tab.setAttribute('aria-selected', active ? 'true' : 'false');
+      if (active) {
+        requestAnimationFrame(() => panel.pane.refresh());
+      }
+    });
+
+    this.activePanelId = id;
+    this.expand();
+  }
+
+  public getActivePanelId(): string | null {
+    return this.activePanelId;
+  }
+
+  /** Toggle collapse state */
+  public toggleCollapse(): void {
+    if (this.collapsed) {
+      this.expand();
+    } else {
+      this.collapse();
+    }
+  }
+
+  public collapse(): void {
+    if (this.collapsed) return;
+    this.collapsed = true;
+    this.root.classList.add('is-collapsed');
+    this.collapseButton.setAttribute('aria-expanded', 'false');
+  }
+
+  public expand(): void {
+    if (!this.collapsed) return;
+    this.collapsed = false;
+    this.root.classList.remove('is-collapsed');
+    this.collapseButton.setAttribute('aria-expanded', 'true');
+  }
+
+  public isCollapsed(): boolean {
+    return this.collapsed;
+  }
+
+  public setDock(dock: DashboardDock): void {
+    if (this.dock === dock) return;
+    this.dock = dock;
+    this.applyDock(dock);
+  }
+
+  public getDock(): DashboardDock {
+    return this.dock;
+  }
+
+  public updateTheme(patch: Partial<DashboardTheme>, persist = true): void {
+    this.theme = { ...this.theme, ...patch };
+    this.applyTheme(this.theme, persist);
+  }
+
+  public applyTheme(theme: DashboardTheme, persist = true): void {
+    this.theme = { ...theme };
+    this.applyThemeVariables();
+    if (persist) {
+      this.persistTheme();
+    }
+  }
+
+  public getTheme(): DashboardTheme {
+    return { ...this.theme };
+  }
+
+  public setTabBadge(id: string, text: string): void {
+    const instance = this.panels.get(id);
+    if (!instance) return;
+    const badge = instance.tab.querySelector<HTMLSpanElement>('.aurora-tab-badge');
+    if (!badge) return;
+    badge.textContent = text;
+    badge.classList.toggle('is-visible', text.trim().length > 0);
+  }
+
+  /** Clean up the dashboard */
+  public destroy(): void {
+    this.panels.forEach(({ pane }) => pane.dispose());
+    this.panels.clear();
+    this.styleSheet.remove();
+    this.root.remove();
+  }
+
+  private createRoot(): HTMLDivElement {
+    const root = document.createElement('div');
+    root.className = 'aurora-dashboard';
+    root.setAttribute('data-dock', this.dock);
+    root.addEventListener('transitionend', () => {
+      if (this.activePanelId) {
+        const panel = this.panels.get(this.activePanelId);
+        panel?.pane.refresh();
+      }
+    });
+    return root;
+  }
+
+  private createTabRail(): HTMLDivElement {
+    const rail = document.createElement('div');
+    rail.className = 'aurora-tab-rail';
+    rail.setAttribute('role', 'tablist');
+    return rail;
+  }
+
+  private createTabList(): HTMLDivElement {
+    const list = document.createElement('div');
+    list.className = 'aurora-tab-list';
+    return list;
+  }
+
+  private createPanelViewport(): HTMLDivElement {
+    const viewport = document.createElement('div');
+    viewport.className = 'aurora-panel-viewport';
+    viewport.addEventListener('wheel', (event) => {
+      if (this.collapsed) {
+        event.preventDefault();
+      }
+    }, { passive: true });
+    return viewport;
+  }
+
+  private createCollapseButton(): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'aurora-collapse';
+    button.setAttribute('aria-expanded', 'true');
+    button.innerHTML = `
+      <span class="aurora-collapse-icon">⤢</span>
+      <span class="aurora-collapse-label">Collapse</span>
+    `;
+    button.addEventListener('click', () => this.toggleCollapse());
+    return button;
+  }
+
+  private createDragHandle(): HTMLDivElement {
+    const handle = document.createElement('div');
+    handle.className = 'aurora-drag-handle';
+    handle.title = 'Drag to dock on a different edge';
+    handle.addEventListener('pointerdown', (event) => this.handleDragStart(event));
+    return handle;
+  }
+
+  private createResizeHandle(): HTMLDivElement {
+    const handle = document.createElement('div');
+    handle.className = 'aurora-resize-handle';
+    handle.title = 'Resize panel';
+    handle.addEventListener('pointerdown', (event) => this.handleResizeStart(event));
+    return handle;
+  }
+
+  private handleDragStart(event: PointerEvent): void {
+    if (event.button !== 0) return;
+    this.dragState = {
+      pointerId: event.pointerId,
+      offsetX: event.clientX - this.root.getBoundingClientRect().left,
+      offsetY: event.clientY - this.root.getBoundingClientRect().top,
+    };
+    this.root.classList.add('is-dragging');
+    window.addEventListener('pointermove', this.handleDragMove);
+    window.addEventListener('pointerup', this.handleDragEnd, { once: false });
+  }
+
+  private handleDragMove = (event: PointerEvent): void => {
+    if (!this.dragState) return;
+    const left = event.clientX - this.dragState.offsetX;
+    const top = event.clientY - this.dragState.offsetY;
+    this.root.style.left = `${left}px`;
+    this.root.style.top = `${top}px`;
+    this.root.style.right = 'auto';
+    this.root.style.bottom = 'auto';
+    this.root.style.transform = '';
+  };
+
+  private handleDragEnd = (event: PointerEvent): void => {
+    if (!this.dragState) return;
+    this.root.classList.remove('is-dragging');
+    window.removeEventListener('pointermove', this.handleDragMove);
+    window.removeEventListener('pointerup', this.handleDragEnd);
+
+    const { clientX, clientY } = event;
+    this.dragState = null;
+    this.snapToClosestEdge(clientX, clientY);
+  };
+
+  private snapToClosestEdge(x: number, y: number): void {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+    const distances: Record<DashboardDock, number> = {
+      left: x,
+      right: width - x,
+      bottom: height - y,
+    };
+
+    const target = (Object.entries(distances).sort((a, b) => a[1] - b[1])[0][0]) as DashboardDock;
+    if (target === 'left' || target === 'right') {
+      const rect = this.root.getBoundingClientRect();
+      const top = clamp(y - rect.height * 0.25, 32, window.innerHeight - rect.height - 32);
+      this.sideOffsetTop = top;
+    }
+    this.setDock(target);
+  }
+
+  private handleResizeStart(event: PointerEvent): void {
+    event.preventDefault();
+    this.resizeState = {
+      pointerId: event.pointerId,
+      startWidth: this.dock === 'bottom' ? this.bottomSize.width : this.sideSize.width,
+      startHeight: this.dock === 'bottom' ? this.bottomSize.height : this.sideSize.height,
+      startX: event.clientX,
+      startY: event.clientY,
+    };
+    this.root.classList.add('is-resizing');
+    window.addEventListener('pointermove', this.handleResizeMove);
+    window.addEventListener('pointerup', this.handleResizeEnd, { once: false });
+  }
+
+  private handleResizeMove = (event: PointerEvent): void => {
+    if (!this.resizeState) return;
+    const dx = event.clientX - this.resizeState.startX;
+    const dy = event.clientY - this.resizeState.startY;
+
+    if (this.dock === 'bottom') {
+      const widthLimits = this.bottomSizeLimits.width;
+      const heightLimits = this.bottomSizeLimits.height;
+      const width = clamp(this.resizeState.startWidth + dx, widthLimits[0], Math.min(widthLimits[1], window.innerWidth - 80));
+      const height = clamp(this.resizeState.startHeight - dy, heightLimits[0], heightLimits[1]);
+      this.bottomSize.width = width;
+      this.bottomSize.height = height;
+    } else if (this.dock === 'right') {
+      const widthLimits = this.sideSizeLimits.width;
+      const heightLimits = this.sideSizeLimits.height;
+      const width = clamp(this.resizeState.startWidth - dx, widthLimits[0], widthLimits[1]);
+      const height = clamp(this.resizeState.startHeight + dy, heightLimits[0], Math.min(heightLimits[1], window.innerHeight - 120));
+      this.sideSize.width = width;
+      this.sideSize.height = height;
+    } else {
+      const widthLimits = this.sideSizeLimits.width;
+      const heightLimits = this.sideSizeLimits.height;
+      const width = clamp(this.resizeState.startWidth + dx, widthLimits[0], widthLimits[1]);
+      const height = clamp(this.resizeState.startHeight + dy, heightLimits[0], Math.min(heightLimits[1], window.innerHeight - 120));
+      this.sideSize.width = width;
+      this.sideSize.height = height;
+    }
+
+    this.applyDock(this.dock);
+  };
+
+  private handleResizeEnd = (): void => {
+    this.root.classList.remove('is-resizing');
+    window.removeEventListener('pointermove', this.handleResizeMove);
+    window.removeEventListener('pointerup', this.handleResizeEnd);
+    this.resizeState = null;
+  };
+
+  private applyDock(dock: DashboardDock): void {
+    this.root.dataset.dock = dock;
+    this.root.classList.remove('dock-left', 'dock-right', 'dock-bottom');
+    this.root.classList.add(`dock-${dock}`);
+
+    if (dock === 'left') {
+      this.root.style.left = `${this.sideInset}px`;
+      this.root.style.right = 'auto';
+      this.root.style.bottom = 'auto';
+      this.root.style.top = `${this.sideOffsetTop}px`;
+      this.root.style.width = `${this.sideSize.width}px`;
+      this.root.style.height = `${this.sideSize.height}px`;
+      this.root.style.transform = '';
+    } else if (dock === 'right') {
+      this.root.style.right = `${this.sideInset}px`;
+      this.root.style.left = 'auto';
+      this.root.style.bottom = 'auto';
+      this.root.style.top = `${this.sideOffsetTop}px`;
+      this.root.style.width = `${this.sideSize.width}px`;
+      this.root.style.height = `${this.sideSize.height}px`;
+      this.root.style.transform = '';
+    } else {
+      this.root.style.left = '50%';
+      this.root.style.right = 'auto';
+      this.root.style.bottom = '24px';
+      this.root.style.top = 'auto';
+      this.root.style.width = `${this.bottomSize.width}px`;
+      this.root.style.height = `${this.bottomSize.height}px`;
+      this.root.style.transform = 'translateX(-50%)';
+    }
+
+    this.updateTabOrientation();
+    if (this.activePanelId) {
+      this.panels.get(this.activePanelId)?.pane.refresh();
+    }
+  }
+
+  private updateTabOrientation(): void {
+    this.tabRail.dataset.orientation = this.dock === 'bottom' ? 'horizontal' : 'vertical';
+  }
+
+  private applyThemeVariables(): void {
+    const rootStyle = this.root.style;
+    const theme = this.theme;
+    const accentHsl = hexToHsl(theme.accent);
+    const accentRgb = hexToRgb(theme.accent);
+
+    const backgroundHue = theme.backgroundHue;
+    const backgroundSat = clamp(theme.backgroundSaturation, 0, 1);
+    const baseLight = clamp(theme.backgroundLightness, 0, 1);
+
+    const topColor = hslToCss(backgroundHue - 6, backgroundSat * 100, clamp(baseLight + 0.12, 0, 1) * 100, theme.glassOpacity);
+    const bottomColor = hslToCss(backgroundHue + 10, clamp(backgroundSat + 0.05, 0, 1) * 100, clamp(baseLight - 0.04, 0, 1) * 100, theme.glassOpacity + 0.05);
+    const railColor = hslToCss(backgroundHue - 12, backgroundSat * 100, clamp(baseLight - 0.06, 0, 1) * 100, clamp(theme.glassOpacity + 0.08, 0, 1));
+
+    const borderColor = hslToCss(backgroundHue + 8, backgroundSat * 100, clamp(baseLight + 0.32, 0, 1) * 100, 0.38);
+    const highlightColor = hslToCss(accentHsl.h, accentHsl.s, clamp(accentHsl.l + theme.highlightStrength * 20, 0, 100), 0.45);
+    const textPrimary = hslToCss(backgroundHue, 32, mix(92, 72, theme.textBrightness), 0.98);
+    const textSecondary = hslToCss(backgroundHue - 4, 24, mix(80, 60, theme.textBrightness), 0.72);
+
+    const accent = `hsl(${accentHsl.h}, ${accentHsl.s}%, ${accentHsl.l}%)`;
+    const accentSoft = `hsla(${accentHsl.h}, ${Math.min(100, accentHsl.s + 10)}%, ${Math.min(95, accentHsl.l + 18)}%, 0.5)`;
+    const accentGlow = `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, ${0.18 * theme.shadowStrength})`;
+
+    const shadowPrimary = `0 24px 60px rgba(8, 12, 28, ${0.46 * theme.shadowStrength})`;
+    const shadowAccent = `0 12px 32px ${accentGlow}`;
+    const insetShadow = `inset 0 1px 0 rgba(255, 255, 255, 0.16), inset 0 0 0 1px rgba(255, 255, 255, 0.08)`;
+
+    rootStyle.setProperty('--aurora-accent', accent);
+    rootStyle.setProperty('--aurora-accent-soft', accentSoft);
+    rootStyle.setProperty('--aurora-accent-text', accentHsl.l > 55 ? '#0b132b' : '#f6fbff');
+    rootStyle.setProperty('--aurora-surface-top', topColor);
+    rootStyle.setProperty('--aurora-surface-bottom', bottomColor);
+    rootStyle.setProperty('--aurora-rail-bg', railColor);
+    rootStyle.setProperty('--aurora-border', borderColor);
+    rootStyle.setProperty('--aurora-highlight', highlightColor);
+    rootStyle.setProperty('--aurora-text-primary', textPrimary);
+    rootStyle.setProperty('--aurora-text-secondary', textSecondary);
+    rootStyle.setProperty('--aurora-glass-blur', `${theme.glassBlur}px`);
+    rootStyle.setProperty('--aurora-glass-saturation', `${theme.glassSaturation * 100}%`);
+    rootStyle.setProperty('--aurora-glass-brightness', `${theme.glassBrightness * 100}%`);
+    rootStyle.setProperty('--aurora-radius', `${theme.radius}px`);
+    rootStyle.setProperty('--aurora-shadow', `${shadowPrimary}, ${shadowAccent}, ${insetShadow}`);
+    rootStyle.setProperty('--aurora-inset-shadow', insetShadow);
+  }
+
+  private loadPersistedTheme(): DashboardTheme | null {
+    if (typeof window === 'undefined') return null;
+    try {
+      const raw = window.localStorage.getItem(THEME_STORAGE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as DashboardTheme;
+      return { ...DEFAULT_THEME, ...parsed };
+    } catch (error) {
+      console.warn('[Dashboard] Failed to load theme from storage', error);
+      return null;
+    }
+  }
+
+  private persistTheme(): void {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, JSON.stringify(this.theme));
+    } catch (error) {
+      console.warn('[Dashboard] Failed to persist theme', error);
+    }
+  }
+
   private injectStyles(): HTMLStyleElement {
-    // Remove any existing glassmorphism styles
-    const existing = document.getElementById('flow-glassmorphism-styles');
+    const existing = document.getElementById('aurora-dashboard-styles');
     if (existing) {
       existing.remove();
     }
 
     const style = document.createElement('style');
-    style.id = 'flow-glassmorphism-styles';
+    style.id = 'aurora-dashboard-styles';
     style.textContent = `
-      /* ═══════════════════════════════════════════════════════════════════ */
-      /* 🎨 FLOW GLASSMORPHISM DESIGN SYSTEM - Unified Panel Pipeline v2.0 */
-      /* ═══════════════════════════════════════════════════════════════════ */
-
-      /* Advanced Glassmorphism base - Target all Tweakpane roots (solid/opaque default) */
-      .tp-dfwv,
-      .tp-rotv,
-      [class*="tp-"][class*="v"] > div:first-child,
-      .panel-container > div:first-child {
-        backdrop-filter: blur(50px) saturate(200%) brightness(1.2) contrast(1.15);
-        -webkit-backdrop-filter: blur(50px) saturate(200%) brightness(1.2) contrast(1.15);
-        background: linear-gradient(
-          135deg,
-          rgba(35, 46, 92, 0.78) 0%,
-          rgba(25, 35, 75, 0.68) 50%,
-          rgba(30, 40, 82, 0.73) 100%
-        ) !important;
-        border: 1px solid rgba(255, 255, 255, 0.28);
-        border-radius: 20px !important;
-        box-shadow: 
-          0 16px 48px 0 rgba(0, 0, 0, 0.45),
-          0 4px 24px 0 rgba(80, 120, 180, 0.35),
-          inset 0 1px 0 0 rgba(255, 255, 255, 0.20),
-          inset 0 0 100px 0 rgba(80, 120, 180, 0.08);
-        transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-        overflow: hidden;
-        position: relative;
+      :root {
+        color-scheme: dark;
       }
 
-      /* Subtle inner glow effect (no purple tint) */
-      .tp-dfwv::before,
-      .tp-rotv::before,
-      .panel-container > div:first-child::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 2px;
-        background: linear-gradient(
-          90deg,
-          transparent,
-          rgba(255, 255, 255, 0.3) 30%,
-          rgba(200, 220, 255, 0.3) 70%,
-          transparent
-        );
-        opacity: 0.5;
-        filter: blur(1px);
+      .aurora-dashboard {
+        position: fixed;
+        top: 96px;
+        right: 24px;
+        display: flex;
+        gap: 14px;
+        z-index: 3000;
+        align-items: stretch;
+        transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+          box-shadow 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+          opacity 0.25s ease;
+        will-change: transform, opacity;
+        pointer-events: auto;
       }
 
-      /* Hover: NO CHANGE (keep same appearance) */
-      .tp-dfwv:hover,
-      .tp-rotv:hover,
-      .panel-container:hover > div:first-child {
-        backdrop-filter: blur(50px) saturate(200%) brightness(1.2) contrast(1.15);
-        -webkit-backdrop-filter: blur(50px) saturate(200%) brightness(1.2) contrast(1.15);
-        background: linear-gradient(
-          135deg,
-          rgba(35, 46, 92, 0.78) 0%,
-          rgba(25, 35, 75, 0.68) 50%,
-          rgba(30, 40, 82, 0.73) 100%
-        ) !important;
-        border: 1px solid rgba(255, 255, 255, 0.28);
-        box-shadow: 
-          0 16px 48px 0 rgba(0, 0, 0, 0.45),
-          0 4px 24px 0 rgba(30, 41, 82, 0.35),
-          inset 0 1px 0 0 rgba(255, 255, 255, 0.20),
-          inset 0 0 100px 0 rgba(200, 220, 255, 0.05);
-        /* Removed transform to keep position stable */
-      }
-
-      /* ═══════════════════════════════════════════════════════════════════ */
-      /* 📦 Enhanced Draggable Panel Container System */
-      /* ═══════════════════════════════════════════════════════════════════ */
-
-      .panel-container {
-        position: absolute;
-        z-index: 1000;
-        touch-action: none;
-        user-select: none;
-        filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.15));
-        transition: filter 0.3s ease, transform 0.2s ease;
-        animation: panelFadeIn 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-      }
-
-      @keyframes panelFadeIn {
-        from {
-          opacity: 0;
-          transform: translateY(20px) scale(0.95);
-        }
-        to {
-          opacity: 1;
-          transform: translateY(0) scale(1);
-        }
-      }
-
-      .panel-container:hover {
-        filter: drop-shadow(0 8px 24px rgba(30, 41, 82, 0.3));
-      }
-
-      .panel-container.dragging {
-        z-index: 2000;
-        cursor: grabbing !important;
-        filter: drop-shadow(0 12px 32px rgba(30, 41, 82, 0.4));
-        transform: scale(1.02);
-      }
-
-      /* Enhanced panel header - draggable area */
-      .tp-fldv_t {
-        cursor: grab;
-        transition: all 0.3s ease;
-        position: relative;
-        padding: 12px 16px !important;
-        background: linear-gradient(
-          135deg,
-          rgba(80, 120, 180, 0.08) 0%,
-          rgba(100, 140, 200, 0.05) 100%
-        );
-        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-      }
-
-      .tp-fldv_t::before {
-        content: '';
-        position: absolute;
-        left: 0;
-        top: 0;
-        bottom: 0;
-        width: 3px;
-        background: linear-gradient(
-          180deg,
-          rgba(80, 120, 180, 0.8) 0%,
-          rgba(100, 140, 200, 0.6) 100%
-        );
-        opacity: 0;
-        transition: opacity 0.3s ease;
-      }
-
-      .tp-fldv_t:hover {
-        background: linear-gradient(
-          135deg,
-          rgba(80, 120, 180, 0.12) 0%,
-          rgba(100, 140, 200, 0.08) 100%
-        );
-        border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-      }
-
-      .tp-fldv_t:hover::before {
-        opacity: 1;
-      }
-
-      .tp-fldv_t:active {
+      .aurora-dashboard.is-dragging {
+        transition: none;
         cursor: grabbing;
-        background: rgba(80, 120, 180, 0.15);
       }
 
-      /* Premium title styling with gradient */
-      .tp-fldv_t .tp-fldv_b {
-        background: linear-gradient(
-          135deg,
-          #5078b4 0%,
-          #648cc8 50%,
-          #a78bfa 100%
-        );
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-        font-weight: 700;
-        font-size: 13px;
-        letter-spacing: 0.8px;
-        text-transform: uppercase;
-        text-shadow: 0 2px 8px rgba(80, 120, 180, 0.3);
+      .aurora-dashboard.is-resizing {
+        user-select: none;
       }
 
-      /* Enhanced folder content */
-      .tp-fldv_c {
-        padding: 8px 12px;
-        background: rgba(0, 0, 0, 0.15);
-      }
-
-      /* Nested folder styling */
-      .tp-fldv .tp-fldv {
-        margin: 6px 0;
-        border-radius: 12px;
-        background: rgba(255, 255, 255, 0.02);
-        border: 1px solid rgba(255, 255, 255, 0.05);
-      }
-
-      /* Premium input fields */
-      .tp-rotv_b, .tp-sldtxtv_t, .tp-lblv_v {
-        background: linear-gradient(
-          135deg,
-          rgba(255, 255, 255, 0.06) 0%,
-          rgba(255, 255, 255, 0.03) 100%
-        ) !important;
-        border: 1px solid rgba(255, 255, 255, 0.12);
-        border-radius: 10px;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
-        color: rgba(255, 255, 255, 0.95) !important;
-        font-weight: 500;
-      }
-
-      .tp-rotv_b:hover, .tp-sldtxtv_t:hover {
-        background: linear-gradient(
-          135deg,
-          rgba(255, 255, 255, 0.10) 0%,
-          rgba(255, 255, 255, 0.06) 100%
-        ) !important;
-        border: 1px solid rgba(80, 120, 180, 0.3);
-        box-shadow: 
-          inset 0 1px 2px rgba(0, 0, 0, 0.2),
-          0 0 0 1px rgba(80, 120, 180, 0.1);
-      }
-
-      .tp-rotv_b:focus, .tp-sldtxtv_t:focus {
-        background: linear-gradient(
-          135deg,
-          rgba(255, 255, 255, 0.12) 0%,
-          rgba(255, 255, 255, 0.08) 100%
-        ) !important;
-        border: 1px solid rgba(80, 120, 180, 0.6);
-        box-shadow: 
-          0 0 0 3px rgba(80, 120, 180, 0.15),
-          inset 0 1px 2px rgba(0, 0, 0, 0.2),
-          0 4px 12px rgba(80, 120, 180, 0.2);
-        outline: none;
-      }
-
-      /* Premium labels */
-      .tp-lblv_l {
-        color: rgba(255, 255, 255, 0.95);
-        font-weight: 600;
-        font-size: 11px;
-        letter-spacing: 0.5px;
-        text-transform: uppercase;
-        text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-      }
-
-      /* Premium buttons with animated gradient */
-      .tp-btnv_b {
-        background: linear-gradient(
-          135deg,
-          #5078b4 0%,
-          #5a80b8 25%,
-          #648cc8 50%,
-          #4f46e5 75%,
-          #5078b4 100%
-        ) !important;
-        background-size: 200% 200% !important;
-        border: 1px solid rgba(80, 120, 180, 0.5) !important;
-        border-radius: 12px;
-        color: white !important;
-        font-weight: 700;
-        font-size: 11px;
-        letter-spacing: 0.8px;
-        text-transform: uppercase;
-        padding: 10px 20px;
-        transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-        box-shadow: 
-          0 4px 16px rgba(80, 120, 180, 0.4),
-          inset 0 1px 0 rgba(255, 255, 255, 0.2);
-        position: relative;
-        overflow: hidden;
-        cursor: pointer;
-      }
-
-      .tp-btnv_b::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: -100%;
-        width: 100%;
-        height: 100%;
-        background: linear-gradient(
-          90deg,
-          transparent,
-          rgba(255, 255, 255, 0.2),
-          transparent
-        );
-        transition: left 0.5s ease;
-      }
-
-      .tp-btnv_b:hover {
-        transform: translateY(-3px) scale(1.02);
-        box-shadow: 
-          0 8px 24px rgba(80, 120, 180, 0.5),
-          0 4px 12px rgba(100, 140, 200, 0.3),
-          inset 0 1px 0 rgba(255, 255, 255, 0.3);
-        background-position: 100% 0 !important;
-        border: 1px solid rgba(80, 120, 180, 0.8) !important;
-      }
-
-      .tp-btnv_b:hover::before {
-        left: 100%;
-      }
-
-      .tp-btnv_b:active {
-        transform: translateY(-1px) scale(0.98);
-        box-shadow: 
-          0 4px 12px rgba(80, 120, 180, 0.4),
-          inset 0 2px 4px rgba(0, 0, 0, 0.2);
-      }
-
-      /* Premium sliders */
-      .tp-sldv_t {
-        background: linear-gradient(
-          90deg,
-          rgba(80, 120, 180, 0.15) 0%,
-          rgba(100, 140, 200, 0.08) 100%
-        );
-        border-radius: 12px;
-        height: 6px;
-        box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3);
-        position: relative;
-        overflow: hidden;
-      }
-
-      .tp-sldv_t::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: linear-gradient(
-          90deg,
-          rgba(80, 120, 180, 0.3) 0%,
-          rgba(100, 140, 200, 0.2) 50%,
-          rgba(80, 120, 180, 0.1) 100%
-        );
+      .aurora-dashboard.is-collapsed .aurora-panel-viewport {
+        width: 0;
         opacity: 0;
-        transition: opacity 0.3s ease;
+        pointer-events: none;
+        margin-right: 0;
       }
 
-      .tp-sldv:hover .tp-sldv_t::before {
+      .aurora-dashboard.is-collapsed .aurora-resize-handle {
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      .aurora-tab-rail {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        gap: 16px;
+        background: var(--aurora-rail-bg, rgba(22, 32, 64, 0.72));
+        backdrop-filter: blur(calc(var(--aurora-glass-blur, 40px) * 0.66)) saturate(var(--aurora-glass-saturation, 220%));
+        border-radius: calc(var(--aurora-radius, 20px) * 0.8);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: 0 12px 36px rgba(6, 10, 24, 0.45);
+        padding: 18px 12px;
+      }
+
+      .aurora-tab-rail[data-orientation="horizontal"] {
+        flex-direction: row;
+        align-items: center;
+        padding: 12px 18px;
+      }
+
+      .aurora-drag-handle {
+        width: 32px;
+        height: 6px;
+        border-radius: 999px;
+        background: linear-gradient(90deg, rgba(255,255,255,0.25), rgba(255,255,255,0.08));
+        align-self: center;
+        cursor: grab;
+        transition: transform 0.2s ease, opacity 0.2s ease;
+      }
+
+      .aurora-drag-handle:hover {
+        transform: translateY(-2px);
+      }
+
+      .aurora-tab-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .aurora-tab-rail[data-orientation="horizontal"] .aurora-tab-list {
+        flex-direction: row;
+      }
+
+      .aurora-tab {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-family: 'Inter', 'Segoe UI', sans-serif;
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--aurora-text-secondary, rgba(230, 240, 255, 0.7));
+        background: transparent;
+        border: none;
+        border-radius: 16px;
+        padding: 10px 14px;
+        cursor: pointer;
+        transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
+        text-align: left;
+      }
+
+      .aurora-tab::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background: linear-gradient(135deg, rgba(255,255,255,0.16), rgba(255,255,255,0));
+        opacity: 0;
+        transition: opacity 0.25s ease;
+      }
+
+      .aurora-tab .aurora-tab-icon {
+        font-size: 16px;
+        filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.4));
+      }
+
+      .aurora-tab .aurora-tab-badge {
+        margin-left: auto;
+        padding: 0 8px;
+        font-size: 11px;
+        font-weight: 600;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.12);
+        color: var(--aurora-text-primary, #f5f8ff);
+        opacity: 0;
+        transform: translateY(-4px);
+        transition: opacity 0.2s ease, transform 0.2s ease;
+      }
+
+      .aurora-tab .aurora-tab-badge.is-visible {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      .aurora-tab:hover {
+        background: rgba(255, 255, 255, 0.05);
+        color: var(--aurora-text-primary, #f5f8ff);
+      }
+
+      .aurora-tab:hover::after {
+        opacity: 0.35;
+      }
+
+      .aurora-tab.is-active {
+        background: linear-gradient(135deg, var(--aurora-accent-soft, rgba(125, 211, 255, 0.3)), rgba(255,255,255,0.04));
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+        color: var(--aurora-accent-text, #0b132b);
+        transform: translateX(2px);
+      }
+
+      .aurora-tab.is-active::after {
+        opacity: 0.4;
+      }
+
+      .aurora-collapse {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 10px 12px;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        color: var(--aurora-text-secondary, rgba(230, 240, 255, 0.65));
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        cursor: pointer;
+        transition: background 0.25s ease, color 0.25s ease;
+      }
+
+      .aurora-collapse:hover {
+        background: rgba(255, 255, 255, 0.1);
+        color: var(--aurora-text-primary, #f5f8ff);
+      }
+
+      .aurora-dashboard.is-collapsed .aurora-collapse {
+        background: rgba(255, 255, 255, 0.14);
+        color: var(--aurora-accent-text, #0b132b);
+      }
+
+      .aurora-panel-viewport {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: stretch;
+        border-radius: var(--aurora-radius, 20px);
+        box-shadow: var(--aurora-shadow, 0 20px 50px rgba(8, 12, 28, 0.5));
+        overflow: hidden;
+        transition: width 0.3s ease, opacity 0.3s ease;
+        background: linear-gradient(135deg, var(--aurora-surface-top, rgba(28,40,72,0.76)), var(--aurora-surface-bottom, rgba(18,26,52,0.84)));
+        backdrop-filter: blur(var(--aurora-glass-blur, 42px)) saturate(var(--aurora-glass-saturation, 210%)) brightness(var(--aurora-glass-brightness, 112%));
+        border: 1px solid var(--aurora-border, rgba(255,255,255,0.25));
+      }
+
+      .aurora-panel-page {
+        flex: 1;
+        display: none;
+        padding: 12px 16px 18px;
+        overflow-y: auto;
+        scrollbar-width: thin;
+      }
+
+      .aurora-panel-page.is-active {
+        display: block;
+      }
+
+      .aurora-panel-page::-webkit-scrollbar {
+        width: 6px;
+      }
+
+      .aurora-panel-page::-webkit-scrollbar-thumb {
+        background: rgba(255, 255, 255, 0.15);
+        border-radius: 999px;
+      }
+
+      .aurora-resize-handle {
+        position: absolute;
+        right: 18px;
+        bottom: 14px;
+        width: 18px;
+        height: 18px;
+        border-radius: 4px;
+        background: linear-gradient(135deg, rgba(255,255,255,0.38), rgba(255,255,255,0.08));
+        opacity: 0.55;
+        cursor: nwse-resize;
+        transition: opacity 0.2s ease;
+        pointer-events: auto;
+      }
+
+      .aurora-resize-handle:hover {
         opacity: 1;
       }
 
-      .tp-sldv_k {
-        background: linear-gradient(
-          135deg,
-          #a78bfa 0%,
-          #5078b4 50%,
-          #5a80b8 100%
-        );
+      .aurora-dashboard.dock-bottom .aurora-tab-rail {
+        align-self: stretch;
+      }
+
+      .aurora-dashboard.dock-bottom .aurora-resize-handle {
+        right: 22px;
+        bottom: 18px;
+      }
+
+      .aurora-dashboard.dock-bottom .aurora-panel-viewport {
+        min-height: 260px;
+      }
+
+      /* Tweakpane harmonisation */
+      .aurora-panel-viewport .tp-dfwv,
+      .aurora-panel-viewport .tp-rotv {
+        background: transparent !important;
+        box-shadow: none !important;
+      }
+
+      .aurora-panel-viewport .tp-fldv {
+        border-radius: 16px !important;
+        background: rgba(12, 18, 38, 0.38);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        margin-bottom: 12px;
+      }
+
+      .aurora-panel-viewport .tp-fldv_t {
+        font-size: 13px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        color: var(--aurora-text-secondary, rgba(230, 240, 255, 0.7));
+        padding: 12px 16px !important;
+        background: linear-gradient(90deg, rgba(255,255,255,0.06), rgba(255,255,255,0));
+      }
+
+      .aurora-panel-viewport .tp-fldv_t::before {
+        display: none;
+      }
+
+      .aurora-panel-viewport .tp-rotv_v {
+        color: var(--aurora-text-primary, #f5f8ff);
+      }
+
+      .aurora-panel-viewport .tp-btnv {
         border-radius: 12px;
-        box-shadow: 
-          0 2px 8px rgba(80, 120, 180, 0.5),
-          0 0 0 2px rgba(80, 120, 180, 0.2),
-          inset 0 1px 0 rgba(255, 255, 255, 0.3);
-        border: 2px solid rgba(255, 255, 255, 0.2);
-        transition: all 0.3s ease;
-      }
-
-      .tp-sldv_k:hover {
-        box-shadow: 
-          0 4px 16px rgba(80, 120, 180, 0.6),
-          0 0 0 3px rgba(80, 120, 180, 0.3),
-          inset 0 1px 0 rgba(255, 255, 255, 0.4);
-        transform: scale(1.15);
-      }
-
-      /* Premium checkbox toggle */
-      .tp-ckbv_i {
-        background: linear-gradient(
-          135deg,
-          rgba(255, 255, 255, 0.08) 0%,
-          rgba(255, 255, 255, 0.04) 100%
-        );
-        border: 2px solid rgba(255, 255, 255, 0.2);
-        border-radius: 8px;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
-        position: relative;
-        overflow: hidden;
-      }
-
-      .tp-ckbv_i::before {
-        content: '';
-        position: absolute;
-        inset: -2px;
-        background: linear-gradient(
-          135deg,
-          rgba(80, 120, 180, 0.5),
-          rgba(100, 140, 200, 0.5)
-        );
-        opacity: 0;
-        transition: opacity 0.3s ease;
-        border-radius: 8px;
-      }
-
-      .tp-ckbv_i:checked {
-        background: linear-gradient(
-          135deg,
-          #5078b4 0%,
-          #5a80b8 50%,
-          #648cc8 100%
-        );
-        border-color: rgba(80, 120, 180, 0.8);
-        box-shadow: 
-          0 4px 12px rgba(80, 120, 180, 0.4),
-          inset 0 1px 0 rgba(255, 255, 255, 0.3);
-      }
-
-      .tp-ckbv_i:hover {
-        border-color: rgba(80, 120, 180, 0.5);
-        box-shadow: 
-          inset 0 1px 3px rgba(0, 0, 0, 0.2),
-          0 0 0 2px rgba(80, 120, 180, 0.2);
-      }
-
-      /* Premium list/dropdown */
-      .tp-lstv_s {
-        background: linear-gradient(
-          135deg,
-          rgba(255, 255, 255, 0.08) 0%,
-          rgba(255, 255, 255, 0.04) 100%
-        ) !important;
-        border: 1px solid rgba(255, 255, 255, 0.15);
-        border-radius: 10px;
-        color: rgba(255, 255, 255, 0.95);
-        padding: 8px 12px;
-        font-weight: 500;
-        transition: all 0.3s ease;
-        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
-      }
-
-      .tp-lstv_s:hover {
-        background: linear-gradient(
-          135deg,
-          rgba(80, 120, 180, 0.12) 0%,
-          rgba(100, 140, 200, 0.08) 100%
-        ) !important;
-        border: 1px solid rgba(80, 120, 180, 0.4);
-        box-shadow: 
-          inset 0 1px 2px rgba(0, 0, 0, 0.2),
-          0 0 0 1px rgba(80, 120, 180, 0.2);
-      }
-
-      .tp-lstv_s:focus {
-        border: 1px solid rgba(80, 120, 180, 0.6);
-        box-shadow: 
-          0 0 0 3px rgba(80, 120, 180, 0.2),
-          inset 0 1px 2px rgba(0, 0, 0, 0.2);
-        outline: none;
-      }
-
-      /* Elegant separator */
-      .tp-sprv_r {
-        background: linear-gradient(
-          90deg,
-          transparent,
-          rgba(80, 120, 180, 0.5) 50%,
-          transparent
-        );
-        height: 2px;
-        margin: 12px 0;
-        border-radius: 2px;
-        box-shadow: 0 1px 3px rgba(80, 120, 180, 0.3);
-      }
-
-      /* Enhanced FPS Graph */
-      .tp-fldv.tp-fpsv {
-        background: linear-gradient(
-          135deg,
-          rgba(15, 23, 42, 0.95) 0%,
-          rgba(15, 23, 42, 0.85) 100%
-        ) !important;
-      }
-
-      .tp-fpsv_g {
-        opacity: 0.9;
-      }
-
-      .tp-fpsv_g path {
-        stroke: url(#fps-gradient);
-        stroke-width: 2;
-        filter: drop-shadow(0 2px 4px rgba(80, 120, 180, 0.5));
-      }
-
-      /* Premium scrollbar */
-      .tp-dfwv::-webkit-scrollbar {
-        width: 10px;
-      }
-
-      .tp-dfwv::-webkit-scrollbar-track {
-        background: rgba(255, 255, 255, 0.03);
-        border-radius: 12px;
-        margin: 4px;
-        box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3);
-      }
-
-      .tp-dfwv::-webkit-scrollbar-thumb {
-        background: linear-gradient(
-          180deg,
-          #5078b4 0%,
-          #5a80b8 50%,
-          #648cc8 100%
-        );
-        border-radius: 12px;
-        border: 2px solid rgba(15, 23, 42, 0.5);
-        box-shadow: 
-          0 2px 8px rgba(80, 120, 180, 0.4),
-          inset 0 1px 0 rgba(255, 255, 255, 0.2);
-        transition: all 0.3s ease;
-      }
-
-      .tp-dfwv::-webkit-scrollbar-thumb:hover {
-        background: linear-gradient(
-          180deg,
-          #a78bfa 0%,
-          #5078b4 50%,
-          #5a80b8 100%
-        );
-        box-shadow: 
-          0 4px 16px rgba(80, 120, 180, 0.6),
-          inset 0 1px 0 rgba(255, 255, 255, 0.3);
-        border-color: rgba(15, 23, 42, 0.3);
-      }
-
-      /* Enhanced animation for panel appearance */
-      @keyframes panelFadeIn {
-        from {
-          opacity: 0;
-          transform: translateY(-20px) scale(0.95);
-          filter: blur(4px);
-        }
-        to {
-          opacity: 1;
-          transform: translateY(0) scale(1);
-          filter: blur(0);
-        }
-      }
-
-      @keyframes panelGlow {
-        0%, 100% {
-          box-shadow: 0 0 20px rgba(80, 120, 180, 0.3);
-        }
-        50% {
-          box-shadow: 0 0 40px rgba(80, 120, 180, 0.5);
-        }
-      }
-
-      .panel-container {
-        animation: panelFadeIn 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-      }
-
-      /* Smooth collapsed state */
-      .tp-fldv.tp-fldv-collapsed .tp-fldv_c {
-        opacity: 0;
-        max-height: 0;
-        overflow: hidden;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-      }
-
-      /* Value display */
-      .tp-txtv_i {
-        color: rgba(255, 255, 255, 0.95) !important;
+        background: linear-gradient(135deg, var(--aurora-accent-soft, rgba(125, 211, 255, 0.3)), rgba(255,255,255,0.06));
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        color: var(--aurora-accent-text, #0b132b);
         font-weight: 600;
       }
 
-      /* Folder expand indicator */
-      .tp-fldv_m {
-        transition: transform 0.3s ease;
+      .aurora-panel-viewport .tp-btnv:hover {
+        background: linear-gradient(135deg, var(--aurora-accent, #7dd3ff), rgba(255,255,255,0.2));
       }
 
-      .tp-fldv.tp-fldv-expanded .tp-fldv_m {
-        transform: rotate(90deg);
-      }
-
-      /* Enhanced binding row */
-      .tp-brkv {
-        background: rgba(255, 255, 255, 0.02);
-        border-radius: 8px;
-        margin: 2px 0;
-        padding: 4px 8px;
-        transition: all 0.2s ease;
-      }
-
-      .tp-brkv:hover {
-        background: rgba(80, 120, 180, 0.08);
-      }
-
-      /* Info dump styling */
-      .tp-infov {
-        background: rgba(255, 255, 255, 0.03) !important;
+      .aurora-panel-viewport .tp-lstv {
         border-radius: 12px;
-        padding: 12px;
-        color: rgba(255, 255, 255, 0.85);
-        line-height: 1.6;
+        background: rgba(12, 18, 38, 0.46);
+        border: 1px solid rgba(255, 255, 255, 0.08);
       }
 
-      .tp-infov a {
-        color: #a78bfa;
-        text-decoration: none;
-        font-weight: 600;
-        transition: color 0.2s ease;
+      .aurora-panel-viewport .tp-rotv {
+        color: var(--aurora-text-primary, #f5f8ff);
       }
 
-      .tp-infov a:hover {
-        color: #5078b4;
-        text-decoration: underline;
+      .aurora-panel-viewport .tp-grdv {
+        background: rgba(255, 255, 255, 0.08);
+        border-radius: 12px;
       }
 
-      /* Mobile responsive */
-      @media (max-width: 768px) {
-        .panel-container {
-          max-width: calc(100vw - 24px) !important;
-        }
-        
-        .tp-dfwv {
-          font-size: 11px;
-          border-radius: 16px !important;
-        }
-
-        .tp-fldv_t {
-          padding: 10px 12px !important;
-        }
-
-        .tp-btnv_b {
-          padding: 8px 16px;
-          font-size: 10px;
-        }
-      }
-
-      /* Touch device optimizations */
-      @media (hover: none) and (pointer: coarse) {
-        .tp-btnv_b:active {
-          transform: scale(0.95);
-        }
-
-        .tp-fldv_t:active {
-          background: rgba(80, 120, 180, 0.2);
-        }
-      }
-
-      /* Dark mode enhancements */
-      @media (prefers-color-scheme: dark) {
-        .tp-dfwv {
-          background: linear-gradient(
-            135deg,
-            rgba(10, 15, 30, 0.90) 0%,
-            rgba(10, 15, 30, 0.80) 100%
-          ) !important;
-        }
-      }
-
-      /* Reduced motion support */
-      @media (prefers-reduced-motion: reduce) {
-        .panel-container,
-        .tp-fldv_t,
-        .tp-btnv_b,
-        * {
-          animation-duration: 0.01ms !important;
-          transition-duration: 0.01ms !important;
-        }
-      }
-
-      /* High contrast mode */
-      @media (prefers-contrast: high) {
-        .tp-dfwv {
-          border: 2px solid rgba(255, 255, 255, 0.5);
-        }
-
-        .tp-lblv_l {
-          color: rgba(255, 255, 255, 1);
+      @media (max-width: 1280px) {
+        .aurora-dashboard {
+          transform-origin: top right;
+          scale: 0.92;
         }
       }
     `;
+
     document.head.appendChild(style);
     return style;
   }
 
-  /**
-   * Create FPS monitor panel
-   */
-  private createFPSPanel(): void {
-    const config: PanelConfig = {
-      title: '📊 Performance',
-      position: { x: 16, y: 16 },
-      expanded: false,
-      draggable: true,
-      collapsible: true,
-    };
-
-    const { pane } = this.createPanel('fps', config);
-    
-    this.fpsGraph = pane.addBlade({
+  private createPerformancePanel(): void {
+    const pane = this.registerPanel({
+      id: 'performance',
+      title: 'Performance',
+      icon: '⏱️',
+      description: 'Real-time FPS metrics',
+    });
+    const fps = pane.addBlade({
       view: 'fpsgraph',
       label: 'FPS',
-      rows: 2,
-    }) as FpsGraphBladeApi;
+      lineCount: 2,
+    }) as unknown as FpsGraphBladeApi;
+    this.fpsGraph = fps;
   }
 
-  /**
-   * Create info panel
-   */
   private createInfoPanel(): void {
-    const config: PanelConfig = {
-      title: 'ℹ️ Information',
-      position: { x: 16, y: window.innerHeight - 320 },
-      expanded: false,
-      draggable: true,
-      collapsible: true,
-    };
-
-    const { pane } = this.createPanel('info', config);
-    pane.registerPlugin(InfodumpPlugin);
-
-    pane.addBlade({
-      view: "infodump",
-      content: 
-        "**WebGPU Particle Flow System**\n\n" +
-        "Realtime MLS-MPM simulation using WebGPU and Three.js TSL.\n\n" +
-        "Inspired by [Refik Anadol](https://refikanadol.com/).\n\n" +
-        "Based on [WebGPU-Ocean](https://github.com/matsuoka-601/WebGPU-Ocean) by matsuoka-601.\n\n" +
-        "[View Source](https://github.com/holtsetio/flow/) • [More Experiments](https://holtsetio.com)",
-      markdown: true,
+    const pane = this.registerPanel({
+      id: 'about',
+      title: 'About',
+      icon: '🧭',
+      description: 'System overview',
     });
 
-    const credits = pane.addFolder({
-      title: "Credits",
-      expanded: false,
-    });
-
-    credits.addBlade({
-      view: "infodump",
-      content: 
-        "• [HDRi background](https://polyhaven.com/a/autumn_field_puresky) by Jarod Guest & Sergej Majboroda\n" +
-        "• [Concrete texture](https://www.texturecan.com/details/216/) by texturecan.com",
-      markdown: true,
-    });
-  }
-
-  /**
-   * Create a new draggable, collapsible panel
-   */
-  public createPanel(id: string, config: PanelConfig): { pane: any; container: HTMLDivElement } {
-    // Create container
-    const container = document.createElement('div');
-    container.className = 'panel-container';
-    container.style.position = 'absolute';
-    container.style.left = `${config.position?.x ?? 16}px`;
-    container.style.top = `${config.position?.y ?? 16}px`;
-    container.style.zIndex = '1000';
-    document.body.appendChild(container);
-
-    // Create pane (using any to work around Tweakpane typing limitations)
-    const pane: any = new Pane({
-      container,
-      title: config.title,
-      expanded: config.expanded ?? true,
-    });
-
-    pane.registerPlugin(EssentialsPlugin);
-
-    // Apply solid frosted glass with tint directly to Tweakpane root element (runtime fallback)
-    requestAnimationFrame(() => {
-      const tweakpaneRoot = container.querySelector('[class*="tp-"]');
-      if (tweakpaneRoot && this.enableGlassmorphism) {
-        const element = tweakpaneRoot as HTMLElement;
-        // Apply solid, opaque frosted glass (hover makes it lighter/more transparent)
-        element.style.backdropFilter = 'blur(50px) saturate(200%) brightness(1.2) contrast(1.15)';
-        element.style.background = 'linear-gradient(135deg, rgba(35, 46, 92, 0.78) 0%, rgba(25, 35, 75, 0.68) 50%, rgba(30, 40, 82, 0.73) 100%)';
-        element.style.border = '1px solid rgba(255, 255, 255, 0.28)';
-        element.style.borderRadius = '20px';
-        element.style.boxShadow = 
-          '0 16px 48px 0 rgba(0, 0, 0, 0.45), ' +
-          '0 4px 24px 0 rgba(30, 41, 82, 0.35), ' +
-          'inset 0 1px 0 0 rgba(255, 255, 255, 0.20), ' +
-          'inset 0 0 100px 0 rgba(200, 220, 255, 0.05)';
-        console.log(`✨ Applied solid frosted glass to panel: ${config.title}`);
-      }
-    });
-
-    // Make draggable
-    if (config.draggable !== false) {
-      this.makeDraggable(container, pane);
-    }
-
-    // Store reference
-    this.panels.set(id, { pane, container });
-
-    return { pane, container };
-  }
-
-  /**
-   * Make a panel draggable
-   */
-  private makeDraggable(container: HTMLDivElement, pane: Pane): void {
-    let isDragging = false;
-    let currentX = 0;
-    let currentY = 0;
-    let initialX = 0;
-    let initialY = 0;
-
-    const dragStart = (e: MouseEvent | TouchEvent) => {
-      const event = 'touches' in e ? e.touches[0] : e;
-      
-      // Only allow dragging from title bar
-      const target = event.target as HTMLElement;
-      if (!target.closest('.tp-fldv_t') && !target.closest('.tp-rotv_t')) {
-        return;
-      }
-
-      isDragging = true;
-      container.classList.add('dragging');
-
-      initialX = event.clientX - currentX;
-      initialY = event.clientY - currentY;
-
-      e.preventDefault();
-    };
-
-    const drag = (e: MouseEvent | TouchEvent) => {
-      if (!isDragging) return;
-
-      const event = 'touches' in e ? e.touches[0] : e;
-
-      currentX = event.clientX - initialX;
-      currentY = event.clientY - initialY;
-
-      // No constraints - move freely anywhere on screen
-      container.style.transform = `translate3d(${currentX}px, ${currentY}px, 0)`;
-    };
-
-    const dragEnd = () => {
-      isDragging = false;
-      container.classList.remove('dragging');
-    };
-
-    // Mouse events
-    container.addEventListener('mousedown', dragStart);
-    document.addEventListener('mousemove', drag);
-    document.addEventListener('mouseup', dragEnd);
-
-    // Touch events
-    container.addEventListener('touchstart', dragStart, { passive: false });
-    document.addEventListener('touchmove', drag, { passive: false });
-    document.addEventListener('touchend', dragEnd);
-  }
-
-  /**
-   * Get a panel by ID
-   */
-  public getPanel(id: string): Pane | undefined {
-    return this.panels.get(id)?.pane;
-  }
-
-  /**
-   * Show/hide a panel
-   */
-  public togglePanel(id: string, visible?: boolean): void {
-    const panel = this.panels.get(id);
-    if (panel) {
-      panel.container.style.display = visible === undefined 
-        ? (panel.container.style.display === 'none' ? 'block' : 'none')
-        : (visible ? 'block' : 'none');
-    }
-  }
-
-  /**
-   * Call at the beginning of each frame for FPS tracking
-   */
-  public begin(): void {
-    this.fpsGraph?.begin();
-  }
-
-  /**
-   * Call at the end of each frame for FPS tracking
-   */
-  public end(): void {
-    this.fpsGraph?.end();
-  }
-
-  /**
-   * Dispose of all UI resources
-   */
-  public dispose(): void {
-    // Dispose all panels
-    this.panels.forEach(({ pane, container }) => {
-      pane.dispose();
-      container.remove();
-    });
-    this.panels.clear();
-
-    // Remove styles
-    this.styleSheet.remove();
+    const info = pane.addFolder({ title: 'Aurora Control Surface', expanded: true });
+    info.addMonitor({ version: '1.0', build: 'adaptive-dashboard' }, 'version', { label: 'Version' });
+    info.addMonitor({ build: 'adaptive-dashboard' }, 'build', { label: 'Build' });
   }
 }
+
+export { DEFAULT_THEME };

--- a/src/PANEL/panels/audio.ts
+++ b/src/PANEL/panels/audio.ts
@@ -4,12 +4,17 @@
  */
 
 import type { Pane } from 'tweakpane';
-import type { AudioConfig, AudioReactiveConfig } from '../config';
-import type { FlowConfig } from '../config';
-import type { Dashboard } from '../PANEL/dashboard';
-import { AudioVisualizationMode } from './audioreactive';
-import { VISUALIZATION_MODE_NAMES } from './audiovisual';
-import type { AudioData } from './soundreactivity';
+import type { AudioConfig, AudioReactiveConfig } from '../../config';
+import type { FlowConfig } from '../../config';
+import type { Dashboard } from '../dashboard';
+import { AudioVisualizationMode } from '../../AUDIO/audioreactive';
+import { VISUALIZATION_MODE_NAMES } from '../../AUDIO/audiovisual';
+import type { AudioData } from '../../AUDIO/soundreactivity';
+
+type PaneContainer = Pick<
+  Pane,
+  'addFolder' | 'addBinding' | 'addMonitor' | 'addBlade' | 'addButton' | 'addInput' | 'addTab' | 'refresh'
+>;
 
 export interface AudioPanelCallbacks {
   onAudioConfigChange?: (config: Partial<AudioConfig>) => void;
@@ -173,51 +178,51 @@ export class AudioPanel {
     this.config = config;
     this.callbacks = callbacks;
     
-    // Create standalone draggable panel
-    const { pane } = dashboard.createPanel('audio', {
+    // Register within the adaptive dashboard shell
+    this.pane = dashboard.registerPanel({
+      id: 'audio',
       title: '🎵 Audio Reactivity',
-      position: { x: window.innerWidth - 340, y: 520 },
-      expanded: true,
-      draggable: true,
-      collapsible: true,
+      icon: '🎵',
+      description: 'Sound-reactive controls, modulation, and monitoring',
     });
-    
-    this.pane = pane;
+
     this.buildPanel();
   }
-  
+
   private buildPanel(): void {
-    // ==================== MAIN CONTROLS ====================
-    this.buildMainControls();
+    const tabs = this.pane.addTab({
+      pages: [
+        { title: 'Essentials' },
+        { title: 'Dynamics' },
+        { title: 'Modulation' },
+        { title: 'Advanced' },
+      ],
+    });
 
-    // ==================== LIVE OVERVIEW ====================
-    this.buildOverview();
+    const essentials = tabs.pages[0] as unknown as PaneContainer;
+    const dynamics = tabs.pages[1] as unknown as PaneContainer;
+    const modulation = tabs.pages[2] as unknown as PaneContainer;
+    const advanced = tabs.pages[3] as unknown as PaneContainer;
 
-    // ==================== FEATURE INSIGHTS ====================
-    this.buildFeatureInsights();
+    this.buildMainControls(essentials);
+    this.buildAudioInput(essentials);
+    this.buildPresets(essentials);
 
-    // ==================== MODULATION LAB ====================
-    this.buildModulationLab();
+    this.buildOverview(dynamics);
+    this.buildFeatureInsights(dynamics);
 
-    // ==================== HISTORY ====================
-    this.buildHistory();
+    this.buildModulationLab(modulation);
 
-    // ==================== AUDIO INPUT ====================
-    this.buildAudioInput();
-
-    // ==================== PRESETS ====================
-    this.buildPresets();
-    
-    // ==================== ADVANCED (Collapsed) ====================
-    this.buildAdvanced();
+    this.buildHistory(advanced);
+    this.buildAdvanced(advanced);
   }
   
   // ========================================
   // MAIN CONTROLS
   // ========================================
   
-  private buildMainControls(): void {
-    const folder = this.pane.addFolder({
+  private buildMainControls(container: PaneContainer = this.pane): void {
+    const folder = container.addFolder({
       title: '🎛️ Main Controls',
       expanded: true,
     });
@@ -256,8 +261,8 @@ export class AudioPanel {
   // LIVE METRICS
   // ========================================
   
-  private buildOverview(): void {
-    const folder = this.pane.addFolder({
+  private buildOverview(container: PaneContainer = this.pane): void {
+    const folder = container.addFolder({
       title: '📊 Live Overview',
       expanded: true,
     });
@@ -321,8 +326,8 @@ export class AudioPanel {
     }));
   }
 
-  private buildFeatureInsights(): void {
-    const folder = this.pane.addFolder({
+  private buildFeatureInsights(container: PaneContainer = this.pane): void {
+    const folder = container.addFolder({
       title: '🧠 Feature Insights',
       expanded: false,
     });
@@ -408,8 +413,8 @@ export class AudioPanel {
     }));
   }
 
-  private buildModulationLab(): void {
-    const folder = this.pane.addFolder({
+  private buildModulationLab(container: PaneContainer = this.pane): void {
+    const folder = container.addFolder({
       title: '🎚️ Modulation Lab',
       expanded: false,
     });
@@ -516,8 +521,8 @@ export class AudioPanel {
     });
   }
 
-  private buildHistory(): void {
-    const folder = this.pane.addFolder({
+  private buildHistory(container: PaneContainer = this.pane): void {
+    const folder = container.addFolder({
       title: '🗂️ Motion History',
       expanded: false,
     });
@@ -542,8 +547,8 @@ export class AudioPanel {
   // AUDIO INPUT
   // ========================================
   
-  private buildAudioInput(): void {
-    const folder = this.pane.addFolder({
+  private buildAudioInput(container: PaneContainer = this.pane): void {
+    const folder = container.addFolder({
       title: '🎤 Audio Source',
       expanded: false,
     });
@@ -603,8 +608,8 @@ export class AudioPanel {
   // PRESETS
   // ========================================
   
-  private buildPresets(): void {
-    const folder = this.pane.addFolder({
+  private buildPresets(container: PaneContainer = this.pane): void {
+    const folder = container.addFolder({
       title: '🎨 Visual Presets',
       expanded: true,
     });
@@ -650,8 +655,8 @@ export class AudioPanel {
   // ADVANCED SETTINGS
   // ========================================
   
-  private buildAdvanced(): void {
-    const folder = this.pane.addFolder({
+  private buildAdvanced(container: PaneContainer = this.pane): void {
+    const folder = container.addFolder({
       title: '⚙️ Advanced',
       expanded: false,
     });

--- a/src/PANEL/panels/postfx.ts
+++ b/src/PANEL/panels/postfx.ts
@@ -2,8 +2,9 @@
  * POSTFX/PANELpostfx.ts - Refined Post-Effects Control Panel
  */
 
-import type { FlowConfig } from '../config';
-import type { Dashboard } from '../PANEL/dashboard';
+import type { Pane } from 'tweakpane';
+import type { FlowConfig } from '../../config';
+import type { Dashboard } from '../dashboard';
 
 export interface PostFXPanelCallbacks {
   onBloomChange?: (config: FlowConfig['bloom']) => void;
@@ -11,8 +12,10 @@ export interface PostFXPanelCallbacks {
   onRadialCAChange?: (config: FlowConfig['radialCA']) => void;
 }
 
+type PaneContainer = Pick<Pane, 'addFolder' | 'addBinding' | 'addBlade'>;
+
 export class PostFXPanel {
-  private pane: any;
+  private pane: Pane;
   private config: FlowConfig;
   private callbacks: PostFXPanelCallbacks;
 
@@ -24,27 +27,36 @@ export class PostFXPanel {
     this.config = config;
     this.callbacks = callbacks;
 
-    const { pane } = dashboard.createPanel('postfx', {
+    this.pane = dashboard.registerPanel({
+      id: 'postfx',
       title: '✨ Post Effects',
-      position: { x: window.innerWidth - 360, y: 16 },
-      expanded: true,
-      draggable: true,
-      collapsible: true,
+      icon: '✨',
+      description: 'Bloom, focus and chromatic controls',
     });
 
-    this.pane = pane;
+    this.buildPanel();
+  }
 
-    this.setupBloomControls();
-    this.setupRadialFocusControls();
-    this.setupRadialCAControls();
+  private buildPanel(): void {
+    const tabs = this.pane.addTab({
+      pages: [
+        { title: 'Glow' },
+        { title: 'Focus' },
+        { title: 'Chromatic' },
+      ],
+    });
+
+    this.setupBloomControls(tabs.pages[0] as unknown as PaneContainer);
+    this.setupRadialFocusControls(tabs.pages[1] as unknown as PaneContainer);
+    this.setupRadialCAControls(tabs.pages[2] as unknown as PaneContainer);
   }
 
   // ========================================
   // BLOOM (HDR-aware glow)
   // ========================================
   
-  private setupBloomControls(): void {
-    const folder = this.pane.addFolder({
+  private setupBloomControls(container: PaneContainer): void {
+    const folder = container.addFolder({
       title: "✨ Bloom",
       expanded: true,
     });
@@ -98,8 +110,8 @@ export class PostFXPanel {
   // RADIAL FOCUS/BLUR (sharp center → blurred edges)
   // ========================================
   
-  private setupRadialFocusControls(): void {
-    const folder = this.pane.addFolder({
+  private setupRadialFocusControls(container: PaneContainer): void {
+    const folder = container.addFolder({
       title: "🎯 Radial Focus",
       expanded: false,
     });
@@ -168,8 +180,8 @@ export class PostFXPanel {
   // RADIAL CHROMATIC ABERRATION (color fringing at edges)
   // ========================================
   
-  private setupRadialCAControls(): void {
-    const folder = this.pane.addFolder({
+  private setupRadialCAControls(container: PaneContainer): void {
+    const folder = container.addFolder({
       title: "🔴 Chromatic Aberration",
       expanded: false,
     });

--- a/src/PANEL/panels/theme.ts
+++ b/src/PANEL/panels/theme.ts
@@ -1,0 +1,405 @@
+/**
+ * PANEL/panels/theme.ts - Theme & preset manager for the adaptive dashboard
+ */
+
+import type { Pane } from 'tweakpane';
+import type { ListBladeApi } from 'tweakpane/dist/types/blade/list/api/list';
+import type { Dashboard, DashboardTheme } from '../dashboard';
+import { DEFAULT_THEME } from '../dashboard';
+
+interface ThemePreset {
+  id: string;
+  name: string;
+  theme: DashboardTheme;
+  builtIn?: boolean;
+}
+
+type PaneContainer = Pick<
+  Pane,
+  'addFolder' | 'addBinding' | 'addBlade' | 'addButton' | 'addInput' | 'addTab' | 'refresh'
+>;
+
+const PRESET_STORAGE_KEY = 'aurora.dashboard.theme.presets';
+
+const BUILT_IN_PRESETS: ThemePreset[] = [
+  { id: 'aurora', name: 'Aurora (Default)', theme: { ...DEFAULT_THEME }, builtIn: true },
+  {
+    id: 'midnight',
+    name: 'Midnight Drift',
+    theme: {
+      accent: '#5f6cff',
+      backgroundHue: 222,
+      backgroundSaturation: 0.52,
+      backgroundLightness: 0.18,
+      glassOpacity: 0.82,
+      glassBlur: 48,
+      glassSaturation: 2.4,
+      glassBrightness: 1.06,
+      radius: 24,
+      shadowStrength: 0.95,
+      highlightStrength: 0.6,
+      textBrightness: 0.78,
+    },
+    builtIn: true,
+  },
+  {
+    id: 'solaris',
+    name: 'Solaris Bloom',
+    theme: {
+      accent: '#ffb656',
+      backgroundHue: 32,
+      backgroundSaturation: 0.58,
+      backgroundLightness: 0.32,
+      glassOpacity: 0.74,
+      glassBlur: 36,
+      glassSaturation: 1.9,
+      glassBrightness: 1.18,
+      radius: 20,
+      shadowStrength: 0.75,
+      highlightStrength: 0.85,
+      textBrightness: 0.9,
+    },
+    builtIn: true,
+  },
+  {
+    id: 'spectrum',
+    name: 'Spectrum Aurora',
+    theme: {
+      accent: '#a579ff',
+      backgroundHue: 268,
+      backgroundSaturation: 0.44,
+      backgroundLightness: 0.24,
+      glassOpacity: 0.8,
+      glassBlur: 56,
+      glassSaturation: 2.6,
+      glassBrightness: 1.2,
+      radius: 26,
+      shadowStrength: 0.88,
+      highlightStrength: 0.9,
+      textBrightness: 0.84,
+    },
+    builtIn: true,
+  },
+];
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export class ThemeManagerPanel {
+  private readonly dashboard: Dashboard;
+  private readonly pane: Pane;
+  private presets: ThemePreset[];
+  private themeState: DashboardTheme;
+  private selectedPresetId: string;
+  private controlState = {
+    customName: '',
+  };
+  private presetSelector: ListBladeApi<string> | null = null;
+  private deleteState = {
+    preset: '',
+  };
+
+  constructor(dashboard: Dashboard) {
+    this.dashboard = dashboard;
+    this.presets = this.loadPresets();
+    this.themeState = { ...this.dashboard.getTheme() };
+    this.selectedPresetId = this.matchPresetId(this.themeState) ?? this.presets[0].id;
+    this.pane = dashboard.registerPanel({
+      id: 'theme',
+      title: '🪞 Theme Studio',
+      icon: '🪞',
+      description: 'Curate palettes, presets, and defaults for the dashboard',
+    });
+
+    this.buildPanel();
+  }
+
+  private buildPanel(): void {
+    const tabs = this.pane.addTab({
+      pages: [
+        { title: 'Presets' },
+        { title: 'Surface' },
+        { title: 'Accents' },
+        { title: 'System' },
+      ],
+    });
+
+    const presetsPage = tabs.pages[0] as unknown as PaneContainer;
+    const surfacePage = tabs.pages[1] as unknown as PaneContainer;
+    const accentPage = tabs.pages[2] as unknown as PaneContainer;
+    const systemPage = tabs.pages[3] as unknown as PaneContainer;
+
+    this.buildPresetsPage(presetsPage);
+    this.buildSurfacePage(surfacePage);
+    this.buildAccentPage(accentPage);
+    this.buildSystemPage(systemPage);
+  }
+
+  private buildPresetsPage(container: PaneContainer): void {
+    const folder = container.addFolder({ title: '🎛️ Preset Manager', expanded: true });
+
+    this.presetSelector = folder.addBlade({
+      view: 'list',
+      label: 'Preset',
+      options: this.buildPresetListItems(),
+      value: this.selectedPresetId,
+    }) as ListBladeApi<string>;
+    this.presetSelector.on('change', (ev) => this.applyPreset(ev.value));
+
+    folder.addBlade({ view: 'separator' });
+
+    folder.addButton({ title: 'Set as Default' }).on('click', () => {
+      this.dashboard.applyTheme({ ...this.themeState }, true);
+    });
+
+    folder.addButton({ title: 'Reset to Aurora' }).on('click', () => {
+      this.applyPreset('aurora');
+    });
+
+    const customFolder = container.addFolder({ title: '📝 Custom Presets', expanded: false });
+    customFolder.addInput(this.controlState, 'customName', { label: 'Name' });
+    customFolder.addButton({ title: '💾 Save Preset' }).on('click', () => {
+      this.saveCustomPreset();
+    });
+
+    const deletable = this.presets.filter(p => !p.builtIn);
+    if (deletable.length > 0) {
+      this.deleteState.preset = deletable[0].id;
+      const deleteFolder = container.addFolder({ title: '🗑️ Remove Custom', expanded: false });
+      deleteFolder.addInput(this.deleteState, 'preset', {
+        label: 'Preset',
+        options: deletable.reduce<Record<string, string>>((acc, preset) => {
+          acc[preset.name] = preset.id;
+          return acc;
+        }, {}),
+      });
+      deleteFolder.addButton({ title: 'Delete Selected' }).on('click', () => {
+        this.deletePreset(this.deleteState.preset);
+      });
+    }
+  }
+
+  private buildSurfacePage(container: PaneContainer): void {
+    const folder = container.addFolder({ title: 'Surface & Glass', expanded: true });
+
+    folder.addBinding(this.themeState, 'backgroundHue', {
+      label: 'Hue',
+      min: 0,
+      max: 360,
+      step: 1,
+    }).on('change', (ev: any) => this.commitTheme({ backgroundHue: ev.value }));
+
+    folder.addBinding(this.themeState, 'backgroundSaturation', {
+      label: 'Saturation',
+      min: 0,
+      max: 1,
+      step: 0.01,
+    }).on('change', (ev: any) => this.commitTheme({ backgroundSaturation: clamp(ev.value, 0, 1) }));
+
+    folder.addBinding(this.themeState, 'backgroundLightness', {
+      label: 'Lightness',
+      min: 0,
+      max: 1,
+      step: 0.01,
+    }).on('change', (ev: any) => this.commitTheme({ backgroundLightness: clamp(ev.value, 0, 1) }));
+
+    folder.addBlade({ view: 'separator' });
+
+    folder.addBinding(this.themeState, 'glassOpacity', {
+      label: 'Opacity',
+      min: 0.5,
+      max: 0.95,
+      step: 0.01,
+    }).on('change', (ev: any) => this.commitTheme({ glassOpacity: ev.value }));
+
+    folder.addBinding(this.themeState, 'glassBlur', {
+      label: 'Blur',
+      min: 12,
+      max: 64,
+      step: 1,
+    }).on('change', (ev: any) => this.commitTheme({ glassBlur: ev.value }));
+
+    folder.addBinding(this.themeState, 'glassSaturation', {
+      label: 'Saturation Boost',
+      min: 1.0,
+      max: 3.0,
+      step: 0.05,
+    }).on('change', (ev: any) => this.commitTheme({ glassSaturation: ev.value }));
+
+    folder.addBinding(this.themeState, 'glassBrightness', {
+      label: 'Brightness',
+      min: 0.7,
+      max: 1.4,
+      step: 0.01,
+    }).on('change', (ev: any) => this.commitTheme({ glassBrightness: ev.value }));
+
+    folder.addBinding(this.themeState, 'radius', {
+      label: 'Corner Radius',
+      min: 14,
+      max: 32,
+      step: 1,
+    }).on('change', (ev: any) => this.commitTheme({ radius: ev.value }));
+  }
+
+  private buildAccentPage(container: PaneContainer): void {
+    const folder = container.addFolder({ title: 'Accents & Lighting', expanded: true });
+
+    folder.addInput(this.themeState, 'accent', {
+      label: 'Accent',
+      view: 'color',
+    }).on('change', (ev: any) => this.commitTheme({ accent: ev.value }));
+
+    folder.addBinding(this.themeState, 'highlightStrength', {
+      label: 'Highlight',
+      min: 0,
+      max: 1,
+      step: 0.01,
+    }).on('change', (ev: any) => this.commitTheme({ highlightStrength: ev.value }));
+
+    folder.addBinding(this.themeState, 'shadowStrength', {
+      label: 'Shadow',
+      min: 0.4,
+      max: 1,
+      step: 0.01,
+    }).on('change', (ev: any) => this.commitTheme({ shadowStrength: ev.value }));
+
+    folder.addBinding(this.themeState, 'textBrightness', {
+      label: 'Text Brightness',
+      min: 0.6,
+      max: 1,
+      step: 0.01,
+    }).on('change', (ev: any) => this.commitTheme({ textBrightness: ev.value }));
+  }
+
+  private buildSystemPage(container: PaneContainer): void {
+    const folder = container.addFolder({ title: 'System Theme', expanded: true });
+
+    folder.addMonitor(this.themeState, 'backgroundHue', { label: 'Hue' });
+    folder.addMonitor(this.themeState, 'glassBlur', { label: 'Blur' });
+    folder.addMonitor(this.themeState, 'glassOpacity', { label: 'Opacity' });
+    folder.addMonitor(this.themeState, 'accent', { label: 'Accent' });
+
+    folder.addBlade({ view: 'separator' });
+
+    folder.addButton({ title: '🔄 Revert Unsaved Changes' }).on('click', () => {
+      this.refreshFromDashboard();
+    });
+  }
+
+  private applyPreset(id: string): void {
+    const preset = this.presets.find((p) => p.id === id);
+    if (!preset) return;
+
+    this.themeState = { ...preset.theme };
+    this.selectedPresetId = id;
+    this.dashboard.applyTheme({ ...this.themeState }, false);
+    this.refreshPresetSelector();
+    this.pane.refresh();
+  }
+
+  private saveCustomPreset(): void {
+    const name = this.controlState.customName.trim();
+    if (!name) {
+      alert('Please provide a name for your preset.');
+      return;
+    }
+
+    const id = `${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${Date.now().toString(36)}`;
+    const preset: ThemePreset = {
+      id,
+      name,
+      theme: { ...this.themeState },
+    };
+
+    this.presets.push(preset);
+    this.persistCustomPresets();
+    this.selectedPresetId = id;
+    this.controlState.customName = '';
+    this.refreshPresetSelector();
+    this.pane.refresh();
+  }
+
+  private deletePreset(id: string): void {
+    const index = this.presets.findIndex((preset) => preset.id === id && !preset.builtIn);
+    if (index === -1) return;
+
+    const removed = this.presets.splice(index, 1)[0];
+    this.persistCustomPresets();
+
+    if (this.selectedPresetId === removed.id) {
+      this.applyPreset('aurora');
+    }
+
+    const remaining = this.presets.filter((preset) => !preset.builtIn && preset.id !== 'custom');
+    this.deleteState.preset = remaining[0]?.id ?? '';
+
+    this.refreshPresetSelector();
+    this.pane.refresh();
+  }
+
+  private commitTheme(partial: Partial<DashboardTheme>): void {
+    this.themeState = { ...this.themeState, ...partial };
+    this.dashboard.updateTheme(partial, false);
+    this.selectedPresetId = 'custom';
+    if (!this.presets.find((p) => p.id === 'custom')) {
+      this.presets.unshift({ id: 'custom', name: 'Custom Session', theme: { ...this.themeState } });
+    } else {
+      const custom = this.presets.find((p) => p.id === 'custom');
+      if (custom) custom.theme = { ...this.themeState };
+    }
+    this.refreshPresetSelector();
+  }
+
+  private refreshFromDashboard(): void {
+    this.themeState = { ...this.dashboard.getTheme() };
+    this.selectedPresetId = this.matchPresetId(this.themeState) ?? this.selectedPresetId;
+    this.refreshPresetSelector();
+    this.pane.refresh();
+  }
+
+  private loadPresets(): ThemePreset[] {
+    const stored = this.loadStoredPresets();
+    return [...BUILT_IN_PRESETS, ...stored];
+  }
+
+  private loadStoredPresets(): ThemePreset[] {
+    if (typeof window === 'undefined') return [];
+    try {
+      const raw = window.localStorage.getItem(PRESET_STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw) as ThemePreset[];
+      return parsed.map((preset) => ({ ...preset, builtIn: false }));
+    } catch (error) {
+      console.warn('[ThemeManager] Failed to load custom presets', error);
+      return [];
+    }
+  }
+
+  private persistCustomPresets(): void {
+    if (typeof window === 'undefined') return;
+    const customs = this.presets.filter((preset) => !preset.builtIn && preset.id !== 'custom');
+    try {
+      window.localStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify(customs));
+    } catch (error) {
+      console.warn('[ThemeManager] Failed to persist custom presets', error);
+    }
+  }
+
+  private matchPresetId(theme: DashboardTheme): string | null {
+    const serialized = JSON.stringify(theme);
+    const found = this.presets.find((preset) => JSON.stringify(preset.theme) === serialized);
+    return found ? found.id : null;
+  }
+
+  private buildPresetListItems(): { text: string; value: string }[] {
+    return this.presets.map((preset) => ({ text: preset.name, value: preset.id }));
+  }
+
+  private refreshPresetSelector(): void {
+    if (this.presetSelector) {
+      this.presetSelector.options = this.buildPresetListItems();
+      this.presetSelector.value = this.selectedPresetId;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a vertical-tab dashboard with docking, resizing, and glassmorphism theme variables
- move all panel implementations under src/PANEL/panels and refactor them to integrate with the new shell
- introduce a theme manager tab with presets, customization controls, and persistence plus document the redesign plan

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5d6d54bbc8327b22b08bb2dce8dec