### PR TITLE
Enhance audio reactivity metrics and boundary response

### DIFF
--- a/src/APP.ts
+++ b/src/APP.ts
@@ -523,6 +523,10 @@ export class FlowApp {
         mid: audioData.smoothMid,
         treble: audioData.smoothTreble,
         beatIntensity: audioData.beatIntensity,
+        containment: audioData.modulators.containment,
+        flow: audioData.modulators.flow,
+        shimmer: audioData.modulators.shimmer,
+        sway: audioData.modulators.sway,
       });
     } else {
       this.boundaries.update(elapsed);

--- a/src/PANEL/panels/audio.ts
+++ b/src/PANEL/panels/audio.ts
@@ -157,6 +157,20 @@ export class AudioPanel {
     warp: 0,
     density: 0,
     aura: 0,
+    containment: 0,
+    sway: 0,
+  };
+
+  private motionReadouts = {
+    expansion: 0,
+    sway: 0,
+    sparkle: 0,
+  };
+
+  private dynamicsReadouts = {
+    momentum: 0,
+    acceleration: 0,
+    breath: 0,
   };
 
   private sparklineState = {
@@ -168,6 +182,8 @@ export class AudioPanel {
   private metricBindings: any[] = [];
   private featureBindings: any[] = [];
   private modulatorBindings: any[] = [];
+  private motionBindings: any[] = [];
+  private dynamicsBindings: any[] = [];
   private sparklineBindings: any[] = [];
   
   constructor(
@@ -210,6 +226,7 @@ export class AudioPanel {
 
     this.buildOverview(dynamics);
     this.buildFeatureInsights(dynamics);
+    this.buildMotionDynamics(dynamics);
 
     this.buildModulationLab(modulation);
 
@@ -413,6 +430,67 @@ export class AudioPanel {
     }));
   }
 
+  private buildMotionDynamics(container: PaneContainer = this.pane): void {
+    const motionFolder = container.addFolder({
+      title: '🌬️ Motion Field',
+      expanded: false,
+    });
+
+    this.motionBindings.push(motionFolder.addBinding(this.motionReadouts, 'expansion', {
+      label: 'Expansion',
+      readonly: true,
+      min: 0,
+      max: 1,
+      format: (v: number) => v.toFixed(3),
+    }));
+
+    this.motionBindings.push(motionFolder.addBinding(this.motionReadouts, 'sway', {
+      label: 'Stereo Sway',
+      readonly: true,
+      min: -1,
+      max: 1,
+      format: (v: number) => v.toFixed(3),
+    }));
+
+    this.motionBindings.push(motionFolder.addBinding(this.motionReadouts, 'sparkle', {
+      label: 'Sparkle',
+      readonly: true,
+      min: 0,
+      max: 1,
+      format: (v: number) => v.toFixed(3),
+    }));
+
+    const dynamicsFolder = container.addFolder({
+      title: '🫁 Dynamics Envelope',
+      expanded: false,
+    });
+
+    this.dynamicsBindings.push(dynamicsFolder.addBinding(this.dynamicsReadouts, 'momentum', {
+      label: 'Momentum',
+      readonly: true,
+      min: -1,
+      max: 1,
+      format: (v: number) => v.toFixed(3),
+    }));
+
+    this.dynamicsBindings.push(dynamicsFolder.addBinding(this.dynamicsReadouts, 'acceleration', {
+      label: 'Acceleration',
+      readonly: true,
+      min: -1,
+      max: 1,
+      format: (v: number) => v.toFixed(3),
+    }));
+
+    this.dynamicsBindings.push(dynamicsFolder.addBinding(this.dynamicsReadouts, 'breath', {
+      label: 'Breath',
+      readonly: true,
+      min: 0,
+      max: 1,
+      format: (v: number) => v.toFixed(3),
+    }));
+  }
+
+
   private buildModulationLab(container: PaneContainer = this.pane): void {
     const folder = container.addFolder({
       title: '🎚️ Modulation Lab',
@@ -424,7 +502,7 @@ export class AudioPanel {
       expanded: true,
     });
 
-    (['pulse', 'flow', 'shimmer', 'warp', 'density', 'aura'] as const).forEach((key) => {
+    (['pulse', 'flow', 'shimmer', 'warp', 'density', 'aura', 'containment', 'sway'] as const).forEach((key) => {
       this.modulatorBindings.push(readoutFolder.addBinding(this.modulationReadouts, key, {
         label: key.charAt(0).toUpperCase() + key.slice(1),
         readonly: true,
@@ -722,7 +800,48 @@ export class AudioPanel {
     }).on('change', (ev: any) => {
       this.callbacks.onAudioConfigChange?.({ smoothing: ev.value });
     });
-    
+
+    const responseFolder = folder.addFolder({
+      title: 'Signal Response',
+      expanded: false,
+    });
+
+    responseFolder.addBinding(this.config.audio, 'featureSmoothing', {
+      label: 'Feature Lag',
+      min: 0,
+      max: 0.95,
+      step: 0.01,
+    }).on('change', (ev: any) => {
+      this.callbacks.onAudioConfigChange?.({ featureSmoothing: ev.value });
+    });
+
+    responseFolder.addBinding(this.config.audio, 'modulationSmoothing', {
+      label: 'Modulation Lag',
+      min: 0,
+      max: 0.95,
+      step: 0.01,
+    }).on('change', (ev: any) => {
+      this.callbacks.onAudioConfigChange?.({ modulationSmoothing: ev.value });
+    });
+
+    responseFolder.addBinding(this.config.audio, 'motionSmoothing', {
+      label: 'Motion Lag',
+      min: 0,
+      max: 0.95,
+      step: 0.01,
+    }).on('change', (ev: any) => {
+      this.callbacks.onAudioConfigChange?.({ motionSmoothing: ev.value });
+    });
+
+    responseFolder.addBinding(this.config.audio, 'dynamicsSmoothing', {
+      label: 'Dynamics Lag',
+      min: 0,
+      max: 0.95,
+      step: 0.01,
+    }).on('change', (ev: any) => {
+      this.callbacks.onAudioConfigChange?.({ dynamicsSmoothing: ev.value });
+    });
+
     // Beat sensitivity
     folder.addBinding(this.config.audio, 'beatThreshold', {
       label: 'Beat Sensitivity',
@@ -831,6 +950,16 @@ export class AudioPanel {
     this.modulationReadouts.warp = audio.modulators.warp;
     this.modulationReadouts.density = audio.modulators.density;
     this.modulationReadouts.aura = audio.modulators.aura;
+    this.modulationReadouts.containment = audio.modulators.containment;
+    this.modulationReadouts.sway = audio.modulators.sway;
+
+    this.motionReadouts.expansion = audio.motion.expansion;
+    this.motionReadouts.sway = audio.motion.sway;
+    this.motionReadouts.sparkle = audio.motion.sparkle;
+
+    this.dynamicsReadouts.momentum = audio.dynamics.momentum;
+    this.dynamicsReadouts.acceleration = audio.dynamics.acceleration;
+    this.dynamicsReadouts.breath = audio.dynamics.breath;
 
     this.sparklineState.loudness = this.renderSparkline(audio.history.loudness);
     this.sparklineState.flux = this.renderSparkline(audio.history.flux);
@@ -839,6 +968,8 @@ export class AudioPanel {
     this.metricBindings.forEach((binding) => binding.refresh());
     this.featureBindings.forEach((binding) => binding.refresh());
     this.modulatorBindings.forEach((binding) => binding.refresh());
+    this.motionBindings.forEach((binding) => binding.refresh());
+    this.dynamicsBindings.forEach((binding) => binding.refresh());
     this.sparklineBindings.forEach((binding) => binding.refresh());
   }
   

--- a/src/POSTFX/postfx.ts
+++ b/src/POSTFX/postfx.ts
@@ -385,10 +385,12 @@ export class PostFX {
       const shimmer = modulators.shimmer ?? audioData.smoothTreble;
       const pulse = modulators.pulse ?? audioData.beatIntensity;
       const warp = modulators.warp ?? 0;
+      const containment = modulators.containment ?? audioData.motion?.expansion ?? audioData.smoothOverall;
+      const sway = modulators.sway ?? ((audioData.motion?.sway ?? 0) + 1) * 0.5;
 
-      bloomMixTarget = Math.max(bloomMixTarget, 0.6) + aura * 0.9 * normalizedInfluence;
-      focusMixTarget = Math.max(focusMixTarget, 0.4) + (flow * 0.7 + pulse * 0.3) * normalizedInfluence;
-      caMixTarget = Math.max(caMixTarget, 0.35) + (shimmer * 0.85 + warp * 0.2) * normalizedInfluence;
+      bloomMixTarget = Math.max(bloomMixTarget, 0.6) + (aura * 0.7 + containment * 0.4) * normalizedInfluence;
+      focusMixTarget = Math.max(focusMixTarget, 0.4) + (flow * 0.6 + pulse * 0.25 + containment * 0.35) * normalizedInfluence;
+      caMixTarget = Math.max(caMixTarget, 0.35) + (shimmer * 0.75 + warp * 0.2 + Math.abs(sway - 0.5) * 0.4) * normalizedInfluence;
 
       if (this.baseEnabled.bloom < 0.5) {
         bloomEnableTarget = Math.min(1, aura * 1.25 * normalizedInfluence);

--- a/src/config.ts
+++ b/src/config.ts
@@ -146,6 +146,9 @@ export interface AudioConfig {
   // Advanced analysis tuning
   historySize: number;
   featureSmoothing: number;
+  modulationSmoothing: number;
+  motionSmoothing: number;
+  dynamicsSmoothing: number;
   fluxSmoothing: number;
   onsetSensitivity: number;
   grooveSensitivity: number;
@@ -393,6 +396,9 @@ export const defaultConfig: FlowConfig = {
     maxDecibels: -10,
     historySize: 192,
     featureSmoothing: 0.82,
+    modulationSmoothing: 0.72,
+    motionSmoothing: 0.68,
+    dynamicsSmoothing: 0.78,
     fluxSmoothing: 0.7,
     onsetSensitivity: 0.55,
     grooveSensitivity: 0.45,


### PR DESCRIPTION
## Summary
- extend the audio analysis engine with momentum and motion metrics plus new containment/sway modulators
- feed the richer metrics into audio reactive visuals, post FX, and material modulation for more responsive motion
- smooth particle boundary reactions and surface the new data in the audio control panel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e63c292e7c83278ba56bbafa6db163