### PR TITLE
Add migration proposal and refactor documentation

### DIFF
--- a/docs/File Map.md
+++ b/docs/File Map.md
@@ -1,0 +1,65 @@
+# Target File Map
+
+```
+AURORA/
+├── docs/
+│   ├── Proposal.md
+│   ├── Refactor Plan.md
+│   └── File Map.md
+├── src/
+│   ├── engine/
+│   │   ├── core/
+│   │   │   ├── sceneEngine.ts
+│   │   │   └── contracts/
+│   │   │       └── auroraEngine.ts
+│   │   ├── loaders/
+│   │   │   ├── assetLoader.ts
+│   │   │   └── materials/
+│   │   │       └── index.ts
+│   │   └── systems/
+│   │       ├── animationSystem.ts
+│   │       └── physicsSystem.ts
+│   ├── store/
+│   │   ├── engineStore.ts
+│   │   ├── uiStore.ts
+│   │   └── index.ts
+│   ├── view/
+│   │   ├── r3f/
+│   │   │   ├── AppCanvas.tsx
+│   │   │   ├── controls/
+│   │   │   │   └── OrbitControls.tsx
+│   │   │   ├── scenes/
+│   │   │   │   ├── MainScene.tsx
+│   │   │   │   └── layers/
+│   │   │   │       ├── EnvironmentLayer.tsx
+│   │   │   │       └── EffectsLayer.tsx
+│   │   │   └── hooks/
+│   │   │       ├── useEngineFrame.ts
+│   │   │       └── useSceneAssets.ts
+│   │   ├── controls/
+│   │   │   └── tweakpane/
+│   │   │       ├── debugPanel.ts
+│   │   │       └── presets/
+│   │   │           └── default.json
+│   │   └── ui/
+│   │       ├── layout/
+│   │       │   └── Shell.tsx
+│   │       └── components/
+│   │           └── StatusBar.tsx
+│   ├── routes/
+│   │   ├── index.tsx
+│   │   └── legacyRedirect.tsx
+│   └── utils/
+│       ├── performance/
+│       │   └── metrics.ts
+│       └── testing/
+│           └── visualRegression.ts
+├── tests/
+│   ├── engine/
+│   │   └── sceneEngine.test.ts
+│   └── visual/
+│       └── comparison.spec.ts
+└── package.json
+```
+
+This layout aligns the forthcoming SFM (Simulation-Frontend-Management) separation: `src/engine` hosts headless simulation logic, `src/view` contains presentation and control surfaces, and `src/store` centralizes shared state. The `tests` directory captures both unit and visual regression suites to support the Verify phase.

--- a/docs/Proposal.md
+++ b/docs/Proposal.md
@@ -1,0 +1,34 @@
+# Aurora Migration Proposal
+
+## Executive Summary
+Aurora's legacy Three.js integration has grown tightly coupled to bespoke scene management utilities, which limits maintainability and experiment velocity. This proposal recommends migrating to a modular rendering stack centered on a headless simulation core and a modern React Three Fiber (R3F) presentation layer. The migration will deliver a composable architecture, enable consistent UI tooling through Tweakpane, and simplify state orchestration with lightweight stores such as Zustand or Jotai. The resulting system will support rapid iteration on visual experiences while lowering the cost of onboarding and future refactors.
+
+## Target Tech Stack
+- **Three r180** for the rendering engine baseline, leveraging its improved WebGPU readiness and refreshed loaders.
+- **React Three Fiber (R3F)** to declaratively author scene graphs and integrate with the existing React UI shell.
+- **Tweakpane** to provide live parameter controls for designers and engineers without bespoke panels.
+- **Zustand or Jotai** for scoped state management, enabling deterministic data flow between the headless engine and the R3F presentation layer.
+
+## Risks & Mitigations
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Regression in rendering features during migration | Medium | Maintain a headless engine contract with snapshot tests to validate material, lighting, and animation outputs before swapping presenters. |
+| Performance degradation from React reconciliation | Medium | Employ R3F's `useFrame` hooks and memoized components; profile using React DevTools and Three.js inspector to keep frame budgets in check. |
+| Knowledge gap on new tooling (R3F, Zustand/Jotai) | Low | Schedule focused training sessions and circulate curated documentation before the Replace phase. |
+| Extended downtime due to stepwise rollout | Low | Follow an incremental adapter strategy that keeps the legacy scene available until verification passes in parallel environments. |
+
+## Migration Timeline
+| Phase | Duration | Key Activities |
+| --- | --- | --- |
+| Week 1: Analyze | Inventory existing Three.js utilities, identify implicit contracts, and catalog shader/material usage. |
+| Weeks 2–3: Extract | Isolate the simulation logic into a headless engine module with typed interfaces and regression tests. |
+| Weeks 3–4: Wrap | Implement adapters that expose the headless engine to both the legacy renderer and the new R3F layer, ensuring feature parity. |
+| Weeks 4–5: Replace | Incrementally move presentation responsibilities to R3F components, wiring state through Zustand/Jotai stores and instrumenting Tweakpane controls. |
+| Week 6: Verify | Conduct integrated QA, performance benchmarks, and documentation handoff before decommissioning the legacy renderer. |
+
+## Research Sources
+1. Three.js r180 release notes highlighting WebGPU and loader updates: <https://github.com/mrdoob/three.js/releases/tag/r180>
+2. React Three Fiber documentation on architecture and hooks: <https://docs.pmnd.rs/react-three-fiber/getting-started/introduction>
+3. Tweakpane official guide detailing panel configuration patterns: <https://tweakpane.github.io/docs/>
+4. Zustand documentation covering store patterns and best practices: <https://docs.pmnd.rs/zustand/getting-started/introduction>
+5. Jotai release notes for atom-based state management: <https://github.com/pmndrs/jotai/releases>

--- a/docs/Refactor Plan.md
+++ b/docs/Refactor Plan.md
@@ -1,0 +1,65 @@
+# Aurora Refactor Plan
+
+## Migration Workflow
+1. **Analyze**
+   - Audit existing Three.js scene graph construction, animation loops, and control surfaces.
+   - Document implicit contracts (e.g., global uniforms, shared shader chunks) and log feature parity requirements.
+   - Capture baseline performance metrics (fps, CPU/GPU utilization) to compare post-migration.
+2. **Extract**
+   - Carve out a headless simulation engine that encapsulates physics, timeline progression, and data transforms.
+   - Define TypeScript interfaces for engine inputs/outputs and add Jest-based snapshot or numerical regression tests.
+   - Isolate side effects (timers, DOM queries) behind adapters to simplify downstream composition.
+3. **Wrap**
+   - Build a compatibility layer that presents the headless engine contract to both the legacy Three.js renderer and the new R3F stack.
+   - Introduce Zustand/Jotai stores that mirror engine outputs and expose selectors for view-layer components.
+   - Add Tweakpane bindings that proxy to engine setters without mutating legacy globals.
+4. **Replace**
+   - Implement R3F components for each legacy mesh/material group, replacing imperative constructors with declarative JSX.
+   - Rewire render/update loops to use `@react-three/fiber`'s `Canvas`, `useFrame`, and suspense-ready loaders.
+   - Gradually switch routes or feature flags to point to the R3F presenter while keeping the compatibility layer active.
+5. **Verify**
+   - Run automated visual regression (Chromatic or Playwright + WebGL snapshots) alongside unit/integration suites.
+   - Perform load testing and profiling; compare against Analyze-phase baselines.
+   - Remove legacy renderer paths once acceptance criteria are met and documentation is updated.
+
+## Headless Engine Contract
+```ts
+export interface AuroraEngineConfig {
+  clock: 'internal' | 'external';
+  tickRate: number;
+  initialState: SceneState;
+}
+
+export interface AuroraEngine {
+  configure(config: AuroraEngineConfig): void;
+  getState(): SceneState;
+  subscribe(listener: (state: SceneState) => void): () => void;
+  advance(deltaMs: number): void;
+  setControl(path: string, value: unknown): void;
+}
+```
+- **Inputs**: configuration, control events (from Tweakpane/UI), timeline ticks.
+- **Outputs**: serializable `SceneState` describing camera, lights, meshes, and materials for rendering.
+- **Determinism**: no direct DOM or renderer references; pure data flow to ease testing and multi-renderer support.
+
+## React Three Fiber Wiring
+- Host a single `<Canvas>` root configured for Three r180 and WebGL2/WebGPU fallback once stabilized.
+- Use context providers for Zustand/Jotai stores so nested components can pull engine state via hooks.
+- Map engine entities to R3F primitives (e.g., `<mesh>` with `<bufferGeometry>` and `<meshStandardMaterial>`), memoizing heavy assets with `useMemo` and suspense loaders.
+- Drive animations via `useFrame`, reading from store selectors to minimize renders.
+- Register Tweakpane panels within a React boundary that dispatches to the engine's `setControl` API.
+
+## Legacy to Modern Module Mapping
+| Legacy Module | New Location | Notes |
+| --- | --- | --- |
+| `src/three/SceneManager.ts` | `src/engine/core/sceneEngine.ts` | Moves imperative scene logic into headless engine. |
+| `src/three/loaders/*` | `src/engine/loaders/` | Standardize asset loading with async factories returning serializable descriptors. |
+| `src/three/components/OrbitControls.ts` | `src/view/r3f/controls/OrbitControls.tsx` | Replace manual control wiring with R3F-compatible controls. |
+| `src/ui/panels/DebugPanel.ts` | `src/view/controls/tweakpane/debugPanel.ts` | Rebuild with Tweakpane and store-driven bindings. |
+| `src/state/index.ts` | `src/store/` | Consolidate Zustand/Jotai stores shared between engine and views. |
+
+## Verification Checklist
+- ✅ Engine contract covered by unit tests and snapshot outputs.
+- ✅ Visual parity established through dual-render comparison.
+- ✅ Performance within ±5% of baseline metrics.
+- ✅ Documentation updated for onboarding, including File Map and migration notes.


### PR DESCRIPTION
## Summary
- add an executive proposal summarizing the three.js to R3F migration along with risks, mitigations, and research sources
- document the refactor workflow, engine contract, and module mapping for the migration
- outline the target file map to guide future implementation work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8c7c7d4fc832785797d0ebf7e8088